### PR TITLE
Fixed bug the agendapoint title wasn't being populated, and made sure it's the same in the agenda

### DIFF
--- a/support/behandeling-exporter.js
+++ b/support/behandeling-exporter.js
@@ -75,8 +75,8 @@ function generateBehandelingHTML(agendapunt) {
   const template = Handlebars.compile(templateStr);
   const behandelingUri = agendapunt.behandeling.uri;
   const agendapuntUri = agendapunt.uri;
-  const agendapuntTitle = agendapunt.title;
-  const openbaar = agendapunt.behandeling.openbaar === 'true' ? true : false;
+  const agendapuntTitle = agendapunt.titel;
+  const openbaar = agendapunt.behandeling.openbaar === 'true';
   const document = agendapunt.behandeling.document.content;
   const presentMandatees = agendapunt.behandeling.presentMandatees;
   const notPresentMandatees = agendapunt.behandeling.notPresentMandatees;

--- a/support/templates/agenda-prepublish.hbs
+++ b/support/templates/agenda-prepublish.hbs
@@ -20,9 +20,7 @@
             {{#if agendapunt.aangebrachtNa}}
               <span property="besluit:aangebrachtNa" resource="{{agendapunt.aangebrachtNa}}"></span>
             {{/if}}
-            <p property="dc:title">
-                {{agendapunt.titel}}
-            </p>
+            <p property="dc:title">{{agendapunt.titel}}</p>
             {{#if agendapunt.beschrijving}}
               <p property="dc:description">
                 {{agendapunt.beschrijving}}

--- a/support/templates/behandeling-html.hbs
+++ b/support/templates/behandeling-html.hbs
@@ -9,7 +9,7 @@
     {{/if}}
   </span>
   <h3 class="h4" resource="{{agendapuntUri}}" property="dc:subject"> 
-    <span property="dc:title">{{agendapuntTitle}} </span>
+    <span property="dc:title">{{agendapuntTitle}}</span>
   </h3>
   <h4 class="h6">Aanwezigen bij agendapunt</h4>
   <br />


### PR DESCRIPTION
I know in the issue it says to not annotate it, but I discovered the only reason the agendapoint title was not present in the behandeling is because of a typo, and it was annotated before in the old prepublish service. I made sure there is not difference in whitespaces. Anyway I can remove the annotations