### PR TITLE
Use a job for a pre-publishing

### DIFF
--- a/routes/preview.js
+++ b/routes/preview.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import { uuid } from 'mu';
 import { constructHtmlForAgenda } from '../support/agenda-utils';
-import { buildBesluitenLijstForMeetingId, publishVersionedBesluitenlijst } from '../support/besluit-exporter';
+import { buildBesluitenLijstForMeetingId } from '../support/besluit-exporter';
 import { buildAllExtractsForMeeting, buildExtractData, constructHtmlForExtract } from '../support/extract-utils';
 import InvalidRequest from '../support/invalid-request';
 import { constructHtmlForMeetingNotes } from '../support/notulen-utils';

--- a/routes/preview.js
+++ b/routes/preview.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import { uuid } from 'mu';
 import { constructHtmlForAgenda } from '../support/agenda-utils';
-import { buildBesluitenLijstForMeetingId } from '../support/besluit-exporter';
+import { buildBesluitenLijstForMeetingId, publishVersionedBesluitenlijst } from '../support/besluit-exporter';
 import { buildAllExtractsForMeeting, buildExtractData, constructHtmlForExtract } from '../support/extract-utils';
 import InvalidRequest from '../support/invalid-request';
 import { constructHtmlForMeetingNotes } from '../support/notulen-utils';
@@ -15,6 +15,61 @@ const router = express.Router();
  * PREPUBLICATION ENDPOINTS
  *
  */
+
+/**
+ * Contains the job results.
+ */
+const prepublishJobResults = new Map();
+
+/**
+ * Adds a job result.
+ *
+ * @param {string} uuid The uuid of the job.
+ * @param {number} status HTTP status code.
+ * @param {object} result The response to send to the user.
+ */
+function pushJobResult( uuid, status, result ) {
+  prepublishJobResults.set( uuid, { status, result } );
+}
+
+/**
+ * Creates a new job.
+ *
+ * @param res Ngenix response object.
+ * @return job Uuid
+ */
+function yieldJobId(res) {
+  const jobUuid = uuid();
+  res
+    .status(200)
+    .send({
+      data: {
+        attributes: {
+          jobId: jobUuid
+        },
+        type: "prebulish-jobs"
+      }
+    });
+
+  return jobUuid;
+}
+
+router.get('/prepublish/job-result/:jobUuid', (req, res) => {
+  const jobUuid = req.params.jobUuid;
+
+  if( prepublishJobResults.has(jobUuid) ) {
+    const { status, result } = prepublishJobResults.get(jobUuid);
+    prepublishJobResults.delete(jobUuid);
+    res
+      .status( status )
+      .send( result );
+  } else {
+    res
+      .status( 404 )
+      .send("UUID not found, production may be ongoing yet.");
+  }
+});
+
 
 /**
 * Prepublish an agenda as HTML+RDFa snippet for a given document
@@ -62,17 +117,18 @@ router.get('/prepublish/besluitenlijst/:meetingUuid', async function(req, res, n
  * Prepublish besluiten as HTML+RDFa snippet for a given document
  * The snippets are not persisted in the store
  */
-router.get('/prepublish/behandelingen/:zittingIdentifier', async function(req, res, next) {
+router.get('/prepublish/behandelingen/:zittingIdentifier', async function(req, res) {
+  const jobUuid = yieldJobId( res );
+
   try {
     const extracts = await buildAllExtractsForMeeting(req.params.zittingIdentifier);
-    return res.send(extracts).end();
+    pushJobResult(jobUuid, 200, extracts);
+    // return res.send(extracts).end();
   }
   catch (err) {
     console.log(err);
-    const error = new Error(`An error occured while fetching contents for prepublished besluiten ${req.params.documentIdentifier}: ${err}`);
-    // @ts-ignore
-    error.status = 500;
-    return next(error);
+    const errorString = `An error occured while fetching contents for prepublished besluiten ${req.params.zittingIdentifier}: ${err}`;
+    pushJobResult(jobUuid, 500, errorString);
   }
 });
 


### PR DESCRIPTION
The prepublisher con now emit jobs for lengthy operations.

Options:

- [ ] We might want to extract the job route and handling code into a separate file
- [ ] We may want to add this for the notulen too