### PR TITLE
make sure each user can start one signing task

### DIFF
--- a/models/task.js
+++ b/models/task.js
@@ -67,7 +67,7 @@ export default class Task {
       return null;
   }
 
-  static async query({meetingUri, type}) {
+  static async query({meetingUri, type, userUri = null}) {
     const result = await query(`
      PREFIX    mu: <http://mu.semte.ch/vocabularies/core/>
      PREFIX    nuao: <http://www.semanticdesktop.org/ontologies/2010/01/25/nuao#>
@@ -83,6 +83,7 @@ export default class Task {
             nuao:involves ${sparqlEscapeUri(meetingUri)};
             dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
             adms:status ?status.
+       ${userUri ? `?uri nuao:involves ${sparqlEscapeUri(userUri)}.` : ''}
      }
    `);
     if (result.results.bindings.length) {

--- a/routes/signing.js
+++ b/routes/signing.js
@@ -13,6 +13,7 @@ import {ensureVersionedAgendaForMeeting, signVersionedAgenda} from '../support/a
 import {ensureVersionedBesluitenLijstForZitting, signVersionedBesluitenlijst} from '../support/besluit-exporter';
 import {ensureVersionedNotulen, NOTULEN_KIND_FULL, signVersionedNotulen} from '../support/notulen-utils';
 import {ensureVersionedExtract, signVersionedExtract} from '../support/extract-utils';
+import {fetchCurrentUser} from '../support/query-utils';
 const router = express.Router();
 
 /**
@@ -56,7 +57,8 @@ router.post('/signing/besluitenlijst/sign/:zittingIdentifier', async function(re
   try {
     const meetingUuid = req.params.zittingIdentifier;
     const meeting = await Meeting.find(meetingUuid);
-    signingTask = await Task.query({meetingUri: meeting.uri, type: TASK_TYPE_SIGNING_DECISION_LIST});
+    const userUri = await fetchCurrentUser(req.header("MU-SESSION-ID"));
+    signingTask = await Task.query({meetingUri: meeting.uri, type: TASK_TYPE_SIGNING_DECISION_LIST, userUri });
     if (!signingTask) {
       signingTask = await Task.create(meeting, TASK_TYPE_SIGNING_DECISION_LIST);
     }

--- a/support/query-utils.js
+++ b/support/query-utils.js
@@ -6,6 +6,24 @@ export async function fetchParticipationListForTreatment(resourceUri) {
   return fetchParticipationList(resourceUri, "besluit:heeftAanwezige", "ext:heeftAfwezige");
 }
 
+export async function fetchCurrentUser(sessionId) {
+  const q = `
+    ${prefixMap.get("muSession").toSparqlString()}
+    ${prefixMap.get("dct").toSparqlString()}
+    ${prefixMap.get("foaf").toSparqlString()}
+  SELECT ?userUri
+  WHERE {
+    ${sparqlEscapeUri(sessionId)} muSession:account/^foaf:account ?userUri.
+  }
+  `;
+  const result = query(q);
+  if (result?.results?.bindings.length === 1) {
+    return result.results.bindings.userUri.value;
+  }
+  else {
+    return null;
+  }
+}
 export async function fetchParticipationList(resourceUri, presentPredicate = "besluit:heeftAanwezigeBijStart", absentPredicate = "ext:heeftAfwezigeBijStart") {
   const presentQuery = await query(`
     ${prefixMap.get("besluit").toSparqlString()}


### PR DESCRIPTION
previously had a logic error that was hidden by incorrect authorization rights, once fixed the decision list could only be signed once. now signing tasks are bound to a user and that user can only start one.