### PR TITLE
Only insert the attachments if we find the decision container

### DIFF
--- a/support/editor-document.js
+++ b/support/editor-document.js
@@ -105,7 +105,9 @@ function appendAttachmentsToDocument(documentContent, attachments, previewType) 
   for(let decisionKey in attachmentsGrouped) {
     const htmlToAdd = generateAttachmentPart(attachmentsGrouped[decisionKey], previewType);
     const decisionContainer = dom.window.document.querySelector(`[resource="${decisionKey}"]`);
-    decisionContainer.insertAdjacentHTML('beforeend', htmlToAdd);
+    if(decisionContainer) {
+      decisionContainer.insertAdjacentHTML('beforeend', htmlToAdd);
+    }
   }
   return dom.window.document.body.innerHTML;
 }


### PR DESCRIPTION
This error https://binnenland.atlassian.net/browse/GN-2998 is because it doesn't find the decision the attachment is linked to, this can happen if you create an attachment and then delete the decision, in that case we can't easily recover from the error so I guess we treat the attachment as if it wasn't linked to anything 