### PR TITLE
write versionednotulen, published and signed resource contents to file

### DIFF
--- a/models/versioned-notulen.js
+++ b/models/versioned-notulen.js
@@ -1,9 +1,13 @@
 // @ts-ignore
 import { uuid, query, sparqlEscapeString, update, sparqlEscapeUri } from 'mu';
-import { hackedSparqlEscapeString } from '../support/pre-importer';
-import { persistContentToFile, writeFileMetadataToDb, getFileContentForUri } from '../support/file-utils';
+import {
+  persistContentToFile,
+  writeFileMetadataToDb,
+  getFileContentForUri,
+} from '../support/file-utils';
 import { prefixMap } from '../support/prefixes';
-const AGENDAPOINT_TYPE_PLANNED = 'http://lblod.data.gift/concepts/bdf68a65-ce15-42c8-ae1b-19eeb39e20d0';
+const AGENDAPOINT_TYPE_PLANNED =
+  'http://lblod.data.gift/concepts/bdf68a65-ce15-42c8-ae1b-19eeb39e20d0';
 
 export default class VersionedNotulen {
   static async query({ kind, meeting }) {
@@ -32,11 +36,15 @@ export default class VersionedNotulen {
       let html;
       if (fileUri) {
         html = await getFileContentForUri(fileUri);
-      }
-      else {
+      } else {
         html = binding.content?.value;
       }
-      return new VersionedNotulen({uri: binding.uri.value, html,  kind, meeting: meeting.uri});
+      return new VersionedNotulen({
+        uri: binding.uri.value,
+        html,
+        kind,
+        meeting: meeting.uri,
+      });
     } else {
       return null;
     }
@@ -47,7 +55,7 @@ export default class VersionedNotulen {
     const versionedNotulenUri = `http://data.lblod.info/versioned-notulen/${versionedNotulenUuid}`;
     const fileInfo = await persistContentToFile(html);
     const logicalFileUri = await writeFileMetadataToDb(fileInfo);
-    await update( `
+    await update(`
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       PREFIX pav: <http://purl.org/pav/>

--- a/models/versioned-notulen.js
+++ b/models/versioned-notulen.js
@@ -1,24 +1,24 @@
 // @ts-ignore
 import { uuid, query, sparqlEscapeString, update, sparqlEscapeUri } from 'mu';
 import { hackedSparqlEscapeString } from '../support/pre-importer';
-
-const AGENDAPOINT_TYPE_PLANNED =
-  'http://lblod.data.gift/concepts/bdf68a65-ce15-42c8-ae1b-19eeb39e20d0';
+import { persistContentToFile, writeFileMetadataToDb, getFileContentForUri } from '../support/file-utils';
+import { prefixMap } from '../support/prefixes';
+const AGENDAPOINT_TYPE_PLANNED = 'http://lblod.data.gift/concepts/bdf68a65-ce15-42c8-ae1b-19eeb39e20d0';
 
 export default class VersionedNotulen {
   static async query({ kind, meeting }) {
     const r = await query(`
-    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-    PREFIX pav: <http://purl.org/pav/>
-    PREFIX prov: <http://www.w3.org/ns/prov#>
-    PREFIX sign: <http://mu.semte.ch/vocabularies/ext/signing/>
+    ${prefixMap.get('ext').toSparqlString()}
+    ${prefixMap.get('mu').toSparqlString()}
+    ${prefixMap.get('prov').toSparqlString()}
+    ${prefixMap.get('nie').toSparqlString()}
 
     SELECT ?uri ?html
     WHERE {
       ?uri a ext:VersionedNotulen;
-                  ext:notulenKind ${sparqlEscapeString(kind)};
-                  ext:content ?html.
+                  ext:notulenKind ${sparqlEscapeString(kind)}.
+      OPTIONAL { ?uri ext:content ?html. }
+      OPTIONAL { ?uri prov:generated/^nie:dataSource ?fileUri. }
       ${sparqlEscapeUri(meeting.uri)} ext:hasVersionedNotulen  ?uri.
       FILTER NOT EXISTS { ?uri ext:deleted "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> }
     } LIMIT 1
@@ -26,13 +26,17 @@ export default class VersionedNotulen {
     const bindings = r.results.bindings;
     if (bindings.length > 0) {
       const binding = bindings[0];
+
       console.log(binding);
-      return new VersionedNotulen({
-        uri: binding.uri.value,
-        html: binding.html.value,
-        kind,
-        meeting: meeting.uri,
-      });
+      const fileUri = bindings.fileUri?.value;
+      let html;
+      if (fileUri) {
+        html = await getFileContentForUri(fileUri);
+      }
+      else {
+        html = binding.content?.value;
+      }
+      return new VersionedNotulen({uri: binding.uri.value, html,  kind, meeting: meeting.uri});
     } else {
       return null;
     }
@@ -41,7 +45,9 @@ export default class VersionedNotulen {
   static async create({ kind, meeting, html, publicTreatments }) {
     const versionedNotulenUuid = uuid();
     const versionedNotulenUri = `http://data.lblod.info/versioned-notulen/${versionedNotulenUuid}`;
-    await update(`
+    const fileInfo = await persistContentToFile(html);
+    const logicalFileUri = await writeFileMetadataToDb(fileInfo);
+    await update( `
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       PREFIX pav: <http://purl.org/pav/>
@@ -50,7 +56,7 @@ export default class VersionedNotulen {
       INSERT DATA{
         ${sparqlEscapeUri(versionedNotulenUri)}
           a ext:VersionedNotulen;
-          ext:content ${hackedSparqlEscapeString(html)};
+          prov:generated ${sparqlEscapeUri(logicalFileUri)};
           ext:notulenKind ${sparqlEscapeString(kind)};
           mu:uuid ${sparqlEscapeString(versionedNotulenUuid)};
           ext:deleted "false"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.

--- a/support/pre-importer.js
+++ b/support/pre-importer.js
@@ -118,7 +118,7 @@ async function handleVersionedResource(
       ${sparqlEscapeUri(newResourceUri)}
         a ${resourceType};
         mu:uuid ${sparqlEscapeString(newResourceUuid)};
-        prov:generated ${sparqlEscapeString(logicalFileUri)};
+        prov:generated ${sparqlEscapeUri(logicalFileUri)};
         sign:signatory ?userUri;
         sign:signatoryRoles ?signatoryRole;
         dct:created ${sparqlEscapeDateTime(now)};

--- a/support/pre-importer.js
+++ b/support/pre-importer.js
@@ -12,7 +12,7 @@ import { signDocument } from './sign-document';
 import {
   getFileContentForUri,
   persistContentToFile,
-  writeFileMetadataToDb
+  writeFileMetadataToDb,
 } from './file-utils';
 
 function cleanupTriples(triples) {
@@ -37,7 +37,6 @@ function hackedSparqlEscapeString(string) {
 }
 
 async function getVersionedContent(uri, contentPredicate) {
-
   const contentQuery = `
         ${prefixMap.get('nie').toSparqlString()}
         ${prefixMap.get('prov').toSparqlString()}
@@ -106,7 +105,7 @@ async function handleVersionedResource(
     ${prefixMap.get('muSession').toSparqlString()}
     ${prefixMap.get('dct').toSparqlString()}
     ${prefixMap.get('foaf').toSparqlString()}
-    ${prefixMap.get("prov").toSparqlString()}
+    ${prefixMap.get('prov').toSparqlString()}
     DELETE {
       ${sparqlEscapeUri(versionedUri)}
         ${statePredicate} ?state.

--- a/support/prefixes.js
+++ b/support/prefixes.js
@@ -29,91 +29,43 @@ class Prefix {
 }
 
 const prefixMap = new Map([
-  ['ext', new Prefix('ext', 'http://mu.semte.ch/vocabularies/ext/')],
-  ['mu', new Prefix('mu', 'http://mu.semte.ch/vocabularies/core/')],
-  [
-    'muSession',
-    new Prefix('muSession', 'http://mu.semte.ch/vocabularies/session/'),
-  ],
-  ['tmp', new Prefix('tmp', 'http://mu.semte.ch/vocabularies/tmp/')],
-  ['besluit', new Prefix('besluit', 'http://data.vlaanderen.be/ns/besluit#')],
-  ['bv', new Prefix('bv', 'http://data.vlaanderen.be/ns/besluitvorming#')],
-  ['mandaat', new Prefix('mandaat', 'http://data.vlaanderen.be/ns/mandaat#')],
-  ['persoon', new Prefix('persoon', 'http://data.vlaanderen.be/ns/persoon#')],
-  [
-    'generiek',
-    new Prefix('generiek', 'http://data.vlaanderen.be/ns/generiek#'),
-  ],
-  [
-    'mobiliteit',
-    new Prefix('mobiliteit', 'https://data.vlaanderen.be/ns/mobiliteit#'),
-  ],
-  [
-    'publicationStatus',
-    new Prefix(
-      'publicationStatus',
-      'http://mu.semte.ch/vocabularies/ext/signing/publication-status/'
-    ),
-  ],
-  ['eli', new Prefix('eli', 'http://data.europa.eu/eli/ontology#')],
-  ['m8g', new Prefix('m8g', 'http://data.europa.eu/m8g/')],
-  ['dct', new Prefix('dct', 'http://purl.org/dc/terms/')],
-  ['cpsv', new Prefix('cpsv', 'http://purl.org/vocab/cpsv#')],
-  [
-    'dul',
-    new Prefix('dul', 'http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#'),
-  ],
-  ['adms', new Prefix('adms', 'http://www.w3.org/ns/adms#')],
-  ['person', new Prefix('person', 'http://www.w3.org/ns/person#')],
-  ['org', new Prefix('org', 'http://www.w3.org/ns/org#')],
-  ['prov', new Prefix('prov', 'http://www.w3.org/ns/prov#')],
-  ['regorg', new Prefix('regorg', 'https://www.w3.org/ns/regorg#')],
-  ['skos', new Prefix('skos', 'http://www.w3.org/2004/02/skos/core#')],
-  ['foaf', new Prefix('foaf', 'http://xmlns.com/foaf/0.1/')],
-  [
-    'nao',
-    new Prefix(
-      'nao',
-      'http://www.semanticdesktop.org/ontologies/2007/08/15/nao#'
-    ),
-  ],
-  ['pav', new Prefix('pav', 'http://purl.org/pav/')],
-  ['schema', new Prefix('schema', 'http://schema.org/')],
-  ['rdfs', new Prefix('rdfs', 'http://www.w3.org/2000/01/rdf-schema#')],
-  ['sign', new Prefix('sign', 'http://mu.semte.ch/vocabularies/ext/signing/')],
-  [
-    'lblodlg',
-    new Prefix(
-      'lblodlg',
-      'http://data.lblod.info/vocabularies/leidinggevenden/'
-    ),
-  ],
-  [
-    'lblodmow',
-    new Prefix('lblodmow', 'http://data.lblod.info/vocabularies/mobiliteit/'),
-  ],
-  ['locn', new Prefix('locn', 'http://www.w3.org/ns/locn#')],
-  ['adres', new Prefix('adres', 'https://data.vlaanderen.be/ns/adres#')],
-  ['persoon', new Prefix('persoon', 'http://data.vlaanderen.be/ns/persoon#')],
-  [
-    'notulen',
-    new Prefix('notulen', 'http://lblod.data.gift/vocabularies/notulen/'),
-  ],
-  [
-    'nfo',
-    new Prefix(
-      'nfo',
-      'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#'
-    ),
-  ],
-  [
-    'nie',
-    new Prefix(
-      'nie',
-      'http://www.semanticdesktop.org/ontologies/2007/01/19/nie#'
-    ),
-  ],
-  ['dbpedia', new Prefix('dbpedia', 'http://dbpedia.org/ontology/')],
+  ["ext", new Prefix("ext", "http://mu.semte.ch/vocabularies/ext/")],
+  ["mu", new Prefix("mu", "http://mu.semte.ch/vocabularies/core/")],
+  ["muSession", new Prefix("muSession", "http://mu.semte.ch/vocabularies/session/")],
+  ["tmp", new Prefix("tmp", "http://mu.semte.ch/vocabularies/tmp/")],
+  ["besluit", new Prefix("besluit", "http://data.vlaanderen.be/ns/besluit#")],
+  ["bv", new Prefix("bv", "http://data.vlaanderen.be/ns/besluitvorming#")],
+  ["mandaat", new Prefix("mandaat", "http://data.vlaanderen.be/ns/mandaat#")],
+  ["persoon", new Prefix("persoon", "http://data.vlaanderen.be/ns/persoon#")],
+  ["generiek", new Prefix("generiek", "http://data.vlaanderen.be/ns/generiek#")],
+  ["mobiliteit", new Prefix("mobiliteit", "https://data.vlaanderen.be/ns/mobiliteit#")],
+  ["publicationStatus", new Prefix("publicationStatus", "http://mu.semte.ch/vocabularies/ext/signing/publication-status/")],
+  ["eli", new Prefix("eli", "http://data.europa.eu/eli/ontology#")],
+  ["m8g", new Prefix("m8g", "http://data.europa.eu/m8g/")],
+  ["dct", new Prefix("dct", "http://purl.org/dc/terms/")],
+  ["cpsv", new Prefix("cpsv", "http://purl.org/vocab/cpsv#")],
+  ["dul", new Prefix("dul", "http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#")],
+  ["adms", new Prefix("adms", "http://www.w3.org/ns/adms#")],
+  ["person", new Prefix("person", "http://www.w3.org/ns/person#")],
+  ["org", new Prefix("org", "http://www.w3.org/ns/org#")],
+  ["prov", new Prefix("prov", "http://www.w3.org/ns/prov#")],
+  ["regorg", new Prefix("regorg", "https://www.w3.org/ns/regorg#")],
+  ["skos", new Prefix("skos", "http://www.w3.org/2004/02/skos/core#")],
+  ["foaf", new Prefix("foaf", "http://xmlns.com/foaf/0.1/")],
+  ["nao", new Prefix("nao", "http://www.semanticdesktop.org/ontologies/2007/08/15/nao#")],
+  ["pav", new Prefix("pav", "http://purl.org/pav/")],
+  ["schema", new Prefix("schema", "http://schema.org/")],
+  ["rdfs", new Prefix("rdfs", "http://www.w3.org/2000/01/rdf-schema#")],
+  ["sign", new Prefix("sign", "http://mu.semte.ch/vocabularies/ext/signing/")],
+  ["lblodlg", new Prefix("lblodlg", "http://data.lblod.info/vocabularies/leidinggevenden/")],
+  ["lblodmow", new Prefix("lblodmow", "http://data.lblod.info/vocabularies/mobiliteit/")],
+  ["locn", new Prefix("locn", "http://www.w3.org/ns/locn#")],
+  ["adres", new Prefix("adres", "https://data.vlaanderen.be/ns/adres#")],
+  ["persoon", new Prefix("persoon", "http://data.vlaanderen.be/ns/persoon#")],
+  ["notulen", new Prefix("notulen", "http://lblod.data.gift/vocabularies/notulen/")],
+  ["nfo", new Prefix("nfo", "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#")],
+  ["nie", new Prefix("nie", "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#")],
+  ["dbpedia", new Prefix("dbpedia", "http://dbpedia.org/ontology/")]
 ]);
 
 export { prefixes, prefixMap };

--- a/support/prefixes.js
+++ b/support/prefixes.js
@@ -1,3 +1,4 @@
+/* prefixes used in the generated HTML */
 const prefixes = [
   'eli: http://data.europa.eu/eli/ontology#',
   'prov: http://www.w3.org/ns/prov#',
@@ -28,6 +29,8 @@ class Prefix {
   }
 }
 
+/* prefixes used in queries */
+// prettier-ignore
 const prefixMap = new Map([
   ["ext", new Prefix("ext", "http://mu.semte.ch/vocabularies/ext/")],
   ["mu", new Prefix("mu", "http://mu.semte.ch/vocabularies/core/")],


### PR DESCRIPTION
it didn't make a lot of sense to write very large html blob to the db, so we moved them to files instead. Currently not doing so for agenda, decisions lists and extracts. This could change in the future however.

Will require some changes in the mu-cl-resources domain files and frontend to work correctly in GN. After that probably need to update the producer and consumer + resource config in the publication stack and the publication frontend. I'm considering a service for 'published-resources' to hide some of the complexity from the frontend, but not sure if it's worth the effort