### PR TITLE
Remove spaces on the role in the template

### DIFF
--- a/support/templates/partials/mandatee-list.hbs
+++ b/support/templates/partials/mandatee-list.hbs
@@ -8,13 +8,11 @@
               <span property="foaf:familyName" content={{this.familyName}}></span>
           </span>
           {{#if ../includeRole}}
-            (
-              <span property="org:holds" typeof="mandaat:Mandaat" resource="{{this.positionUri}}">
-                <span property="org:role" typeof="skos:Concept" resource="{{this.roleUri}}">
-                  <span property="skos:prefLabel" content={{this.role}}></span>
-                </span>
+            <span property="org:holds" typeof="mandaat:Mandaat" resource="{{this.positionUri}}">
+              <span property="org:role" typeof="skos:Concept" resource="{{this.roleUri}}">
+                <span property="skos:prefLabel" content={{this.role}}></span>
               </span>
-            )
+            </span>
           {{/if}}
         </div>
       {{/each}}
@@ -31,13 +29,7 @@
                 <span property="foaf:familyName" content={{this.familyName}}>{{this.familyName}} </span>
               </span>
               {{#if ../includeRole}}
-                (
-                  <span property="org:holds" typeof="mandaat:Mandaat" resource="{{this.positionUri}}">
-                    <span property="org:role" typeof="skos:Concept" resource="{{this.roleUri}}">
-                      <span property="skos:prefLabel" content={{this.role}}>{{this.role}}</span>
-                    </span>
-                  </span>
-                )
+                (<span property="org:holds" typeof="mandaat:Mandaat" resource="{{this.positionUri}}"><span property="org:role" typeof="skos:Concept" resource="{{this.roleUri}}"><span property="skos:prefLabel" content={{this.role}}>{{this.role}}</span></span></span>)
               {{/if}}
             </li>
           {{/each}}


### PR DESCRIPTION
I don't really like putting everything in one line, but it's really the only solution without extracting that part to js to trim spaces as far as I know