### PR TITLE
Regulatory statement publishing support

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,15 @@ import previewRouter from './routes/preview';
 import signingRouter from './routes/signing';
 import publicationRouter from './routes/publication';
 import taskRouter from './routes/task';
+import { statSync } from 'fs';
+
+try {
+  const shareStat = statSync('/share/');
+}
+catch(e) {
+  console.error(e);
+  throw 'failed to detect /share folder, make sure to mount a /share folder';
+}
 
 setupHandleBars();
 

--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@ import taskRouter from './routes/task';
 import { statSync } from 'fs';
 
 try {
-  const shareStat = statSync('/share/');
+  statSync('/share/');
 }
 catch(e) {
   console.error(e);

--- a/models/versioned-regulatory-statement.js
+++ b/models/versioned-regulatory-statement.js
@@ -16,20 +16,14 @@ export default class VersionedRegulatoryStatement {
         ?uri a ext:VersionedRegulatoryStatement;
                   mu:uuid ?uuid;
                   ext:reglementaireBijlage ${sparqlEscapeString(regulatoryStatementDocumentUri)}.
-        OPTIONAL { ?uri ext:content ?content. }
-        OPTIONAL { ?uri prov:generated/^nie:dataSource ?fileUri. }
+        ?uri prov:generated/^nie:dataSource ?fileUri.
       }
   `);
     const bindings = r.results.bindings;
     if (bindings.length > 0) {
       const binding = bindings[0];
       const fileUri = binding.fileUri?.value;
-      let html;
-      if (fileUri){
-        html = await getFileContentForUri(fileUri);
-      } else {
-        html = binding.content?.value;
-      }
+      const html = fileUri ? await getFileContentForUri(fileUri) : '';
       return new VersionedRegulatoryStatement({uri: binding.uri.value, html, regulatoryStatementDocument: regulatoryStatementDocumentUri});
     }
     else {

--- a/models/versioned-regulatory-statement.js
+++ b/models/versioned-regulatory-statement.js
@@ -1,0 +1,57 @@
+// @ts-ignore
+import {uuid, query, sparqlEscapeString, update, sparqlEscapeUri} from "mu";
+import { hackedSparqlEscapeString } from '../support/pre-importer';
+
+// using the english name here, but the model is in dutch
+export default class VersionedRegulatoryStatement {
+  static async query({regulatoryStatementDocumentUri}) {
+    const r = await query(`
+      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX pav: <http://purl.org/pav/>
+      PREFIX prov: <http://www.w3.org/ns/prov#>
+      SELECT ?uri ?html ?uuid ?regulatoryStatement
+      WHERE
+      {
+        ?uri a ext:VersionedRegulatoryStatement;
+                  mu:uuid ?uuid;
+                  ext:content ?html;
+                  ext:reglementaireBijlage ${sparqlEscapeString(regulatoryStatementDocumentUri)}.
+      }
+  `);
+    const bindings = r.results.bindings;
+    if (bindings.length > 0) {
+      const binding = bindings[0];
+      return new VersionedRegulatoryStatement({uri: binding.uri.value, html: binding.html.value, regulatoryStatementDocument: regulatoryStatementDocumentUri});
+    }
+    else {
+      return null;
+    }
+  }
+
+  static async create({regulatoryStatementDocumentUri, versionedTreatmentUri, html}) {
+    const versionedRegulatoryStatementUuid = uuid();
+    const versionedRegulatoryStatementUri = `http://data.lblod.info/prepublished-regulatory-statements/${versionedRegulatoryStatementUuid}`;
+    await update(`
+      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX pav: <http://purl.org/pav/>
+      PREFIX prov: <http://www.w3.org/ns/prov#>
+
+      INSERT DATA {
+        ${sparqlEscapeUri(versionedRegulatoryStatementUri)}
+           a ext:VersionedRegulatoryStatement;
+           ext:content ${hackedSparqlEscapeString( html )};
+           mu:uuid ${sparqlEscapeString( versionedRegulatoryStatementUuid )};
+           ext:regulatoryStatement ${sparqlEscapeUri(regulatoryStatementDocumentUri)}.
+        ${sparqlEscapeUri(versionedTreatmentUri)} ext:hasVersionedReglementaireBijlage ${sparqlEscapeUri(versionedRegulatoryStatementUri)}.
+      }`);
+    return new VersionedRegulatoryStatement({html, uri: versionedRegulatoryStatementUri, regulatoryStatementDocument: regulatoryStatementDocumentUri});
+  }
+
+  constructor({uri, html = null, regulatoryStatementDocument}) {
+    this.uri = uri;
+    this.html = html;
+    this.regulatoryStatementDocument = regulatoryStatementDocument;
+  }
+}

--- a/models/versioned-regulatory-statement.js
+++ b/models/versioned-regulatory-statement.js
@@ -1,6 +1,5 @@
 // @ts-ignore
 import {uuid, query, sparqlEscapeString, update, sparqlEscapeUri} from "mu";
-import { hackedSparqlEscapeString } from '../support/pre-importer';
 import { persistContentToFile, writeFileMetadataToDb, getFileContentForUri } from '../support/file-utils';
 import { prefixMap } from '../support/prefixes';
 // using the english name here, but the model is in dutch

--- a/models/versioned-regulatory-statement.js
+++ b/models/versioned-regulatory-statement.js
@@ -1,28 +1,37 @@
 // @ts-ignore
 import {uuid, query, sparqlEscapeString, update, sparqlEscapeUri} from "mu";
 import { hackedSparqlEscapeString } from '../support/pre-importer';
-
+import { persistContentToFile, writeFileMetadataToDb, getFileContentForUri } from '../support/file-utils';
+import { prefixMap } from '../support/prefixes';
 // using the english name here, but the model is in dutch
 export default class VersionedRegulatoryStatement {
   static async query({regulatoryStatementDocumentUri}) {
     const r = await query(`
-      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-      PREFIX pav: <http://purl.org/pav/>
-      PREFIX prov: <http://www.w3.org/ns/prov#>
-      SELECT ?uri ?html ?uuid ?regulatoryStatement
+      ${prefixMap.get('ext').toSparqlString()}
+      ${prefixMap.get('mu').toSparqlString()}
+      ${prefixMap.get('prov').toSparqlString()}
+      ${prefixMap.get('nie').toSparqlString()}
+      SELECT ?uri ?content ?fileUri
       WHERE
       {
         ?uri a ext:VersionedRegulatoryStatement;
                   mu:uuid ?uuid;
-                  ext:content ?html;
                   ext:reglementaireBijlage ${sparqlEscapeString(regulatoryStatementDocumentUri)}.
+        OPTIONAL { ?uri ext:content ?content. }
+        OPTIONAL { ?uri prov:generated/^nie:dataSource ?fileUri. }
       }
   `);
     const bindings = r.results.bindings;
     if (bindings.length > 0) {
       const binding = bindings[0];
-      return new VersionedRegulatoryStatement({uri: binding.uri.value, html: binding.html.value, regulatoryStatementDocument: regulatoryStatementDocumentUri});
+      const fileUri = binding.fileUri?.value;
+      let html;
+      if (fileUri){
+        html = await getFileContentForUri(fileUri);
+      } else {
+        html = binding.content?.value;
+      }
+      return new VersionedRegulatoryStatement({uri: binding.uri.value, html, regulatoryStatementDocument: regulatoryStatementDocumentUri});
     }
     else {
       return null;
@@ -32,6 +41,9 @@ export default class VersionedRegulatoryStatement {
   static async create({regulatoryStatementDocumentUri, versionedTreatmentUri, html}) {
     const versionedRegulatoryStatementUuid = uuid();
     const versionedRegulatoryStatementUri = `http://data.lblod.info/prepublished-regulatory-statements/${versionedRegulatoryStatementUuid}`;
+    const fileInfo = await persistContentToFile(html);
+    const logicalFileUri = await writeFileMetadataToDb(fileInfo);
+    
     await update(`
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -41,7 +53,7 @@ export default class VersionedRegulatoryStatement {
       INSERT DATA {
         ${sparqlEscapeUri(versionedRegulatoryStatementUri)}
            a ext:VersionedRegulatoryStatement;
-           ext:content ${hackedSparqlEscapeString( html )};
+           prov:generated ${sparqlEscapeUri(logicalFileUri)};
            mu:uuid ${sparqlEscapeString( versionedRegulatoryStatementUuid )};
            ext:regulatoryStatement ${sparqlEscapeUri(regulatoryStatementDocumentUri)}.
         ${sparqlEscapeUri(versionedTreatmentUri)} ext:hasVersionedReglementaireBijlage ${sparqlEscapeUri(versionedRegulatoryStatementUri)}.

--- a/routes/publication.js
+++ b/routes/publication.js
@@ -16,6 +16,10 @@ import {
   TASK_TYPE_PUBLISHING_DECISION_LIST,
   TASK_TYPE_PUBLISHING_MEETING_NOTES
 } from '../models/task';
+import { editorDocumentFromUuid } from '../support/editor-document';
+import { getCurrentVersion, getLinkedDocuments } from '../support/editor-document-utils';
+import { getUri } from '../support/resource-utils';
+import { ensureVersionedRegulatoryStatement, publishVersionedRegulatoryStatement } from '../support/regulatory-statement-utils';
 
 
 const router = express.Router();
@@ -99,6 +103,12 @@ router.post('/signing/behandeling/publish/:zittingIdentifier/:behandelingUuid', 
     else {
       const extractUri = await ensureVersionedExtract(treatment, meeting);
       await publishVersionedExtract( extractUri, req.header("MU-SESSION-ID"), "gepubliceerd", treatment.attachments );
+      //Determine which regulatory statements are part of the treatment, ensure they are versioned and publish them.
+      const treatmentEditorDocumentUri = await getUri(treatment.editorDocumentUuid);
+      const linkedRegulatoryStatementContainers = await getLinkedDocuments(treatmentEditorDocumentUri)
+      const linkedRegulatoryStatementDocuments = await Promise.all(linkedRegulatoryStatementContainers.map(async (containerURI) => getCurrentVersion(containerURI)));
+      const versionedRegulatoryStatements = await Promise.all(linkedRegulatoryStatementDocuments.map(async (doc) => ensureVersionedRegulatoryStatement(doc, extractUri)));
+      await Promise.all(versionedRegulatoryStatements.map(async (versionedStatementUri) => publishVersionedRegulatoryStatement(versionedStatementUri, req.header("MU-SESSION-ID"), "gepubliceerd")))
       return res.send( { success: true } ).end();
     }
   } catch (err) {
@@ -152,6 +162,11 @@ router.post('/signing/notulen/publish/:zittingIdentifier', async function(req, r
           if (! published) {
             const extractUri = await ensureVersionedExtract(treatment, meeting);
             await publishVersionedExtract( extractUri, req.header("MU-SESSION-ID"), "gepubliceerd", treatment.attachments );
+            const treatmentEditorDocumentUri = await getUri(treatment.editorDocumentUuid);
+            const linkedRegulatoryStatementContainers = await getLinkedDocuments(treatmentEditorDocumentUri)
+            const linkedRegulatoryStatementDocuments = await Promise.all(linkedRegulatoryStatementContainers.map(async (containerURI) => getCurrentVersion(containerURI)));
+            const versionedRegulatoryStatements = await Promise.all(linkedRegulatoryStatementDocuments.map(async (doc) => ensureVersionedRegulatoryStatement(doc, extractUri)));
+            await Promise.all(versionedRegulatoryStatements.map(async (versionedStatementUri) => publishVersionedRegulatoryStatement(versionedStatementUri, req.header("MU-SESSION-ID"), "gepubliceerd")))
           }
         }
       }

--- a/routes/publication.js
+++ b/routes/publication.js
@@ -16,7 +16,6 @@ import {
   TASK_TYPE_PUBLISHING_DECISION_LIST,
   TASK_TYPE_PUBLISHING_MEETING_NOTES
 } from '../models/task';
-import { editorDocumentFromUuid } from '../support/editor-document';
 import { getCurrentVersion, getLinkedDocuments } from '../support/editor-document-utils';
 import { getUri } from '../support/resource-utils';
 import { ensureVersionedRegulatoryStatement, publishVersionedRegulatoryStatement } from '../support/regulatory-statement-utils';
@@ -105,10 +104,10 @@ router.post('/signing/behandeling/publish/:zittingIdentifier/:behandelingUuid', 
       await publishVersionedExtract( extractUri, req.header("MU-SESSION-ID"), "gepubliceerd", treatment.attachments );
       //Determine which regulatory statements are part of the treatment, ensure they are versioned and publish them.
       const treatmentEditorDocumentUri = await getUri(treatment.editorDocumentUuid);
-      const linkedRegulatoryStatementContainers = await getLinkedDocuments(treatmentEditorDocumentUri)
+      const linkedRegulatoryStatementContainers = await getLinkedDocuments(treatmentEditorDocumentUri);
       const linkedRegulatoryStatementDocuments = await Promise.all(linkedRegulatoryStatementContainers.map(async (containerURI) => getCurrentVersion(containerURI)));
       const versionedRegulatoryStatements = await Promise.all(linkedRegulatoryStatementDocuments.map(async (doc) => ensureVersionedRegulatoryStatement(doc, extractUri)));
-      await Promise.all(versionedRegulatoryStatements.map(async (versionedStatementUri) => publishVersionedRegulatoryStatement(versionedStatementUri, req.header("MU-SESSION-ID"), "gepubliceerd")))
+      await Promise.all(versionedRegulatoryStatements.map(async (versionedStatementUri) => publishVersionedRegulatoryStatement(versionedStatementUri, req.header("MU-SESSION-ID"), "gepubliceerd")));
       return res.send( { success: true } ).end();
     }
   } catch (err) {
@@ -163,10 +162,10 @@ router.post('/signing/notulen/publish/:zittingIdentifier', async function(req, r
             const extractUri = await ensureVersionedExtract(treatment, meeting);
             await publishVersionedExtract( extractUri, req.header("MU-SESSION-ID"), "gepubliceerd", treatment.attachments );
             const treatmentEditorDocumentUri = await getUri(treatment.editorDocumentUuid);
-            const linkedRegulatoryStatementContainers = await getLinkedDocuments(treatmentEditorDocumentUri)
+            const linkedRegulatoryStatementContainers = await getLinkedDocuments(treatmentEditorDocumentUri);
             const linkedRegulatoryStatementDocuments = await Promise.all(linkedRegulatoryStatementContainers.map(async (containerURI) => getCurrentVersion(containerURI)));
             const versionedRegulatoryStatements = await Promise.all(linkedRegulatoryStatementDocuments.map(async (doc) => ensureVersionedRegulatoryStatement(doc, extractUri)));
-            await Promise.all(versionedRegulatoryStatements.map(async (versionedStatementUri) => publishVersionedRegulatoryStatement(versionedStatementUri, req.header("MU-SESSION-ID"), "gepubliceerd")))
+            await Promise.all(versionedRegulatoryStatements.map(async (versionedStatementUri) => publishVersionedRegulatoryStatement(versionedStatementUri, req.header("MU-SESSION-ID"), "gepubliceerd")));
           }
         }
       }

--- a/routes/signing.js
+++ b/routes/signing.js
@@ -102,10 +102,10 @@ router.post('/signing/behandeling/sign/:zittingIdentifier/:behandelingUuid', asy
       const extractUri = await ensureVersionedExtract(treatment, meeting);
       await signVersionedExtract( extractUri, req.header("MU-SESSION-ID"), "getekend", treatment.attachments );
       const treatmentEditorDocumentUri = await getUri(treatment.editorDocumentUuid);
-      const linkedRegulatoryStatementContainers = await getLinkedDocuments(treatmentEditorDocumentUri)
+      const linkedRegulatoryStatementContainers = await getLinkedDocuments(treatmentEditorDocumentUri);
       const linkedRegulatoryStatementDocuments = await Promise.all(linkedRegulatoryStatementContainers.map(async (containerURI) => getCurrentVersion(containerURI)));
       const versionedRegulatoryStatements = await Promise.all(linkedRegulatoryStatementDocuments.map(async (doc) => ensureVersionedRegulatoryStatement(doc, extractUri)));
-      await Promise.all(versionedRegulatoryStatements.map(async (versionedStatementUri) => signVersionedRegulatoryStatement(versionedStatementUri, req.header("MU-SESSION-ID"), "getekend")))
+      await Promise.all(versionedRegulatoryStatements.map(async (versionedStatementUri) => signVersionedRegulatoryStatement(versionedStatementUri, req.header("MU-SESSION-ID"), "getekend")));
       return res.send( { success: true } ).end();
     }
   } catch (err) {

--- a/support/constants.js
+++ b/support/constants.js
@@ -1,2 +1,3 @@
 export const IS_PREVIEW = 'is_preview';
 export const IS_FINAL = 'is_final';
+export const DOCUMENT_PUBLISHED_STATUS = 'http://mu.semte.ch/application/concepts/ef8e4e331c31430bbdefcdb2bdfbcc06';

--- a/support/editor-document-utils.js
+++ b/support/editor-document-utils.js
@@ -1,0 +1,48 @@
+// @ts-ignore
+import { query, sparqlEscapeUri } from 'mu';
+import EditorDocument from './editor-document';
+
+/**
+ * 
+ * Fetches the current version of a document container and returns it as an `EditorDocument` object
+ * 
+ * @param {string} documentContainerUri The URI of the document container
+ * @returns {Promise<EditorDocument>}
+ */
+export async function getCurrentVersion(documentContainerUri) {
+  const currentVersionQuery = await query(`
+      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+      SELECT ?uri ?content ?context WHERE  {
+      ${sparqlEscapeUri(documentContainerUri)} ext:hasCurrentVersion ?uri .
+      ?uri ext:editorDocumentContent ?content;
+                      ext:editorDocumentContext ?context.
+      }
+    `);
+  if (!currentVersionQuery.results.bindings.length)
+    throw new Error('Current version not found for document container' + documentContainerUri);
+
+  const result = currentVersionQuery.results.bindings[0];
+  return new EditorDocument({
+    uri: result.uri.value,
+    context: JSON.parse( result.context.value ),
+    content: result.content.value
+  });
+}
+
+
+/**
+ * 
+ * Function which yields a list of document container URIs which are part of a given editor-document
+ * 
+ * @param {string} editorDocumentUri 
+ * @returns {Promise<string[]>}
+ */
+export async function getLinkedDocuments(editorDocumentUri){
+  const linkedStatementsQuery = await query(`
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    SELECT ?part WHERE  {
+      ?part dct:isPartOf ${sparqlEscapeUri(editorDocumentUri)} .
+    }
+  `);
+  return linkedStatementsQuery.results.bindings.map((binding) => binding.part.value);
+}

--- a/support/editor-document-utils.js
+++ b/support/editor-document-utils.js
@@ -11,9 +11,10 @@ import EditorDocument from './editor-document';
  */
 export async function getCurrentVersion(documentContainerUri) {
   const currentVersionQuery = await query(`
+      PREFIX pav: <http://purl.org/pav/>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       SELECT ?uri ?content ?context WHERE  {
-      ${sparqlEscapeUri(documentContainerUri)} ext:hasCurrentVersion ?uri .
+      ${sparqlEscapeUri(documentContainerUri)} pav:hasCurrentVersion ?uri .
       ?uri ext:editorDocumentContent ?content;
                       ext:editorDocumentContext ?context.
       }
@@ -40,6 +41,7 @@ export async function getCurrentVersion(documentContainerUri) {
 export async function getLinkedDocuments(editorDocumentUri){
   const linkedStatementsQuery = await query(`
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX dct: <http://purl.org/dc/terms/>
     SELECT ?part WHERE  {
       ?part dct:isPartOf ${sparqlEscapeUri(editorDocumentUri)} .
     }

--- a/support/extract-utils.js
+++ b/support/extract-utils.js
@@ -16,9 +16,8 @@ import validateMeeting from './validate-meeting';
 import validateTreatment from './validate-treatment';
 import VersionedExtract from '../models/versioned-behandeling';
 import {handleVersionedResource} from './pre-importer';
-import { IS_FINAL } from './constants';
+import { IS_FINAL, DOCUMENT_PUBLISHED_STATUS } from './constants';
 
-const DOCUMENT_PUBLISHED_STATUS = 'http://mu.semte.ch/application/concepts/ef8e4e331c31430bbdefcdb2bdfbcc06';
 /**
  * This file contains helpers for exporting, signing and publishing an extract of the meeting notes
  * an extract is the treatment of one agendapoint and all it's related info

--- a/support/file-utils.js
+++ b/support/file-utils.js
@@ -34,8 +34,8 @@ export async function writeFileMetadataToDb(metadata) {
   const fileStats = await stat(metadata.path);
   const fileSize = fileStats.size;
   const created = new Date();
-  const fysicalFilename = metadata.filename;
-  const fysicalFileUri = metadata.path.replace('/share/','share://');
+  const physicalFilename = metadata.filename;
+  const physicalFileUri = metadata.path.replace('/share/','share://');
   const fileQuery = `
     ${prefixMap.get('ext').toSparqlString()}
     ${prefixMap.get('mu').toSparqlString()}
@@ -53,9 +53,9 @@ export async function writeFileMetadataToDb(metadata) {
                     nfo:fileSize ${fileSize};
                     dct:created ${sparqlEscapeDateTime(created)};
                     dct:modified ${sparqlEscapeDateTime(created)}.
-         ${sparqlEscapeUri(fysicalFileUri)} a nfo:FileDataObject;
+         ${sparqlEscapeUri(physicalFileUri)} a nfo:FileDataObject;
                     nie:dataSource ${sparqlEscapeUri(logicalFileUri)};
-                    nfo:fileName ${sparqlEscapeUri(fysicalFilename)};
+                    nfo:fileName ${sparqlEscapeUri(physicalFilename)};
                     mu:uuid ${sparqlEscapeUri(metadata.uuid)};
                     nfo:fileSize ${fileSize};
                     dbpedia:fileExtension "html";

--- a/support/file-utils.js
+++ b/support/file-utils.js
@@ -1,0 +1,66 @@
+import { stat, writeFile, readFile } from 'fs/promises';
+import { uuid, update } from 'mu';
+import { sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDateTime } from 'mu';
+import { prefixMap } from '../support/prefixes';
+/**
+ * reads a file from the shared drive and returns its content
+ * @param string shareUri the uri of the file to read
+ * @return string
+ */
+export async function getFileContentForUri(shareUri) {
+  const path = shareUri.replace('share://','/share/');
+  const content = await readFile(path, 'utf8');
+  return content;
+}
+
+/**
+ * write contents to a file in the shared drive and return its path
+ */
+export async function persistContentToFile(content, options) {
+  const fileId = uuid();
+  const filename = `${fileId}.html`;
+  const path = `/share/${filename}`;
+  await writeFile(path, content, "utf8");
+  return {uuid: fileId, path, filename};
+}
+
+
+export async function writeFileMetadataToDb(metadata) {
+  console.log(metadata);
+  const logicalFileUuid = uuid();
+  const logicalFileUri = `http://lblod.data.gift/files/${logicalFileUuid}`;
+  const logicalFileName = metadata.filename;
+  const fileStats = await stat(metadata.path);
+  const fileSize = fileStats.size;
+  const created = new Date();
+  const fysicalFilename = metadata.filename;
+  const fysicalFileUri = metadata.path.replace('/share/','share://');
+  const fileQuery = `
+    ${prefixMap.get('ext').toSparqlString()}
+    ${prefixMap.get('mu').toSparqlString()}
+    ${prefixMap.get('prov').toSparqlString()}
+    ${prefixMap.get('nie').toSparqlString()}
+    ${prefixMap.get('nfo').toSparqlString()}
+    ${prefixMap.get('dct').toSparqlString()}
+    ${prefixMap.get('dbpedia').toSparqlString()}
+   INSERT DATA {
+         ${sparqlEscapeUri(logicalFileUri)} a nfo:FileDataObject;
+                    nfo:fileName ${sparqlEscapeString(logicalFileName)};
+                    mu:uuid ${sparqlEscapeString(logicalFileUuid)};
+                    dct:format "text/html";
+                    dbpedia:fileExtension "html";
+                    nfo:fileSize ${fileSize};
+                    dct:created ${sparqlEscapeDateTime(created)};
+                    dct:modified ${sparqlEscapeDateTime(created)}.
+         ${sparqlEscapeUri(fysicalFileUri)} a nfo:FileDataObject;
+                    nie:dataSource ${sparqlEscapeUri(logicalFileUri)};
+                    nfo:fileName ${sparqlEscapeUri(fysicalFilename)};
+                    mu:uuid ${sparqlEscapeUri(metadata.uuid)};
+                    nfo:fileSize ${fileSize};
+                    dbpedia:fileExtension "html";
+                    dct:created ${sparqlEscapeDateTime(created)};
+                    dct:modified ${sparqlEscapeDateTime(created)}.
+  }`;
+  await update(fileQuery);
+  return logicalFileUri;
+}

--- a/support/file-utils.js
+++ b/support/file-utils.js
@@ -1,10 +1,11 @@
 import { stat, writeFile, readFile } from 'fs/promises';
 import { uuid, update } from 'mu';
+// @ts-ignore
 import { sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDateTime } from 'mu';
 import { prefixMap } from '../support/prefixes';
 /**
  * reads a file from the shared drive and returns its content
- * @param string shareUri the uri of the file to read
+ * @param {string} shareUri the uri of the file to read
  * @return string
  */
 export async function getFileContentForUri(shareUri) {
@@ -16,7 +17,7 @@ export async function getFileContentForUri(shareUri) {
 /**
  * write contents to a file in the shared drive and return its path
  */
-export async function persistContentToFile(content, options) {
+export async function persistContentToFile(content) {
   const fileId = uuid();
   const filename = `${fileId}.html`;
   const path = `/share/${filename}`;

--- a/support/pre-importer.js
+++ b/support/pre-importer.js
@@ -2,7 +2,7 @@
 import {query, update, sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDateTime, uuid} from  'mu';
 import {prefixMap} from "./prefixes";
 import {signDocument} from './sign-document';
-import { getFileContentForUri, persistContentToFile, writeFileMetadataToDb } from './file-utils';
+import { getFileContentForUri } from './file-utils';
 
 function cleanupTriples(triples) {
   const cleantriples = {};

--- a/support/pre-importer.js
+++ b/support/pre-importer.js
@@ -19,6 +19,7 @@ function hackedSparqlEscapeString( string ) {
 
 async function getVersionedContent(uri, contentPredicate) {
   const result = await query(`
+        ${prefixMap.get("nie").toSparqlString()}
         ${prefixMap.get("prov").toSparqlString()}
         ${prefixMap.get("ext").toSparqlString()}
         SELECT ?content ?fysicalFileUri

--- a/support/pre-importer.js
+++ b/support/pre-importer.js
@@ -68,7 +68,7 @@ async function handleVersionedResource( type, versionedUri, sessionId, targetSta
       ${sparqlEscapeUri(newResourceUri)}
         a ${resourceType};
         mu:uuid ${sparqlEscapeString(newResourceUuid)};
-        sign:text ${sparqlEscapeString(content)};
+        sign:text ${hackedSparqlEscapeString(content)};
         sign:signatory ?userUri;
         sign:signatoryRoles ?signatoryRole;
         dct:created ${sparqlEscapeDateTime(now)};

--- a/support/pre-importer.js
+++ b/support/pre-importer.js
@@ -22,10 +22,10 @@ async function getVersionedContent(uri, contentPredicate) {
         ${prefixMap.get("nie").toSparqlString()}
         ${prefixMap.get("prov").toSparqlString()}
         ${prefixMap.get("ext").toSparqlString()}
-        SELECT ?content ?fysicalFileUri
+        SELECT ?content ?physicalFileUri
         WHERE {
          OPTIONAL { ${sparqlEscapeUri(uri)} ${contentPredicate} ?content. }
-         OPTIONAL { ${sparqlEscapeUri(uri)} prov:generated/^nie:dataSource ?fysicalFileUri. }
+         OPTIONAL { ${sparqlEscapeUri(uri)} prov:generated/^nie:dataSource ?physicalFileUri. }
         }`);
   if (result.results.bindings.length == 1) {
     const binding = result.results.bindings[0];
@@ -33,7 +33,7 @@ async function getVersionedContent(uri, contentPredicate) {
       return binding.content.value;
     }
     else {
-      const content = await getFileContentForUri(binding.fysicalFileUri.value);
+      const content = await getFileContentForUri(binding.physicalFileUri.value);
       return content;
     }
   }

--- a/support/prefixes.js
+++ b/support/prefixes.js
@@ -63,7 +63,9 @@ const prefixMap = new Map([
   ["adres", new Prefix("adres", "https://data.vlaanderen.be/ns/adres#")],
   ["persoon", new Prefix("persoon", "http://data.vlaanderen.be/ns/persoon#")],
   ["notulen", new Prefix("notulen", "http://lblod.data.gift/vocabularies/notulen/")],
-  ["nfo", new Prefix("nfo", "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#")]
+  ["nfo", new Prefix("nfo", "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#")],
+  ["nie", new Prefix("nie", "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#")],
+  ["dbpedia", new Prefix("dbpedia", "http://dbpedia.org/ontology/")]
 ]);
 
 export {prefixes, prefixMap};

--- a/support/regulatory-statement-utils.js
+++ b/support/regulatory-statement-utils.js
@@ -3,11 +3,10 @@ import { handleVersionedResource } from "./pre-importer";
 import { query, update, sparqlEscapeUri } from 'mu';
 import { DOCUMENT_PUBLISHED_STATUS } from "./constants";
 import VersionedRegulatoryStatement from "../models/versioned-regulatory-statement";
-import EditorDocument, { editorDocumentFromUri } from "./editor-document";
 
 /**
  * 
- * @param {EditorDocument} regulatoryStatementDocument An editor document object representing the regulatory statement
+ * @param {import('./editor-document').default} regulatoryStatementDocument An editor document object representing the regulatory statement
  * @param {string} versionedTreatmentUri The URI of the versioned treatment the regulatory statement belongs to.
  * @returns {Promise<string>} The URI of the newly created or already existing versioned regulatory statement.
  */
@@ -19,7 +18,7 @@ export async function ensureVersionedRegulatoryStatement(regulatoryStatementDocu
   }
   else {
     const html = regulatoryStatementDocument.content;
-    const versionedRegulatoryStatement = await VersionedRegulatoryStatement.create({ regulatoryStatementDocumentUri: regulatoryStatementDocument.uri, versionedTreatmentUri, html })
+    const versionedRegulatoryStatement = await VersionedRegulatoryStatement.create({ regulatoryStatementDocumentUri: regulatoryStatementDocument.uri, versionedTreatmentUri, html });
     return versionedRegulatoryStatement.uri;
   }
 }

--- a/support/regulatory-statement-utils.js
+++ b/support/regulatory-statement-utils.js
@@ -79,15 +79,3 @@ export async function updateStatusOfLinkedEditorDocument(versionedRegulatoryStat
     }
   `);
 }
-
-// export async function getLinkedRegulatoryStatements(treatmentUri){
-//   const linkedStatementsQuery = await query(`
-//     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-//     SELECT ?regulatoryStatementContainer WHERE  {
-//     ${sparqlEscapeUri(treatmentUri)} ext:hasDocumentContainer ?container .
-//     ?container ext:currentVersion ?hasCurrentVersion .
-//     ?regulatoryStatementContainer dct:isPartOf ?currentVersion .
-//     }
-//   `);
-//   return linkedStatementsQuery.results.bindings.map((binding) => binding.regulatoryStatementContainer.value);
-// }

--- a/support/regulatory-statement-utils.js
+++ b/support/regulatory-statement-utils.js
@@ -1,0 +1,93 @@
+import { handleVersionedResource } from "./pre-importer";
+// @ts-ignore
+import { query, update, sparqlEscapeUri } from 'mu';
+import { DOCUMENT_PUBLISHED_STATUS } from "./constants";
+import VersionedRegulatoryStatement from "../models/versioned-regulatory-statement";
+import EditorDocument, { editorDocumentFromUri } from "./editor-document";
+
+/**
+ * 
+ * @param {EditorDocument} regulatoryStatementDocument An editor document object representing the regulatory statement
+ * @param {string} versionedTreatmentUri The URI of the versioned treatment the regulatory statement belongs to.
+ * @returns {Promise<string>} The URI of the newly created or already existing versioned regulatory statement.
+ */
+export async function ensureVersionedRegulatoryStatement(regulatoryStatementDocument, versionedTreatmentUri) {
+  const versionedRegulatoryStatement = await VersionedRegulatoryStatement.query({ regulatoryStatementDocumentUri: regulatoryStatementDocument.uri });
+  if (versionedRegulatoryStatement) {
+    console.log(`reusing versioned extract for regulatory statement document with uuid  ${regulatoryStatementDocument.uri}`);
+    return versionedRegulatoryStatement.uri;
+  }
+  else {
+    const html = regulatoryStatementDocument.content;
+    const versionedRegulatoryStatement = await VersionedRegulatoryStatement.create({ regulatoryStatementDocumentUri: regulatoryStatementDocument.uri, versionedTreatmentUri, html })
+    return versionedRegulatoryStatement.uri;
+  }
+}
+
+
+/**
+ * 
+ * Function responsible for signing a given versioned regulatory statement
+ * 
+ * @param {string} uri The URI of the versioned regulatory statement that should be signed
+ * @param {string} sessionId 
+ * @param {string} targetStatus New state of versioned regulatory statement
+ */
+export async function signVersionedRegulatoryStatement(uri, sessionId, targetStatus) {
+  await handleVersionedResource("signature", uri, sessionId, targetStatus, 'ext:signsRegulatoryStatement');
+}
+
+
+/**
+ * 
+ * Function responsible for publishing a given versioned regulatory statement
+ * 
+ * @param {string} uri The URI of the versioned regulatory statement that should be published
+ * @param {string} sessionId 
+ * @param {string} targetStatus New state of versioned regulatory statement
+ */
+export async function publishVersionedRegulatoryStatement(uri, sessionId, targetStatus) {
+  await handleVersionedResource("publication", uri, sessionId, targetStatus, 'ext:publishedRegulatoryStatement');
+  await updateStatusOfLinkedEditorDocument(uri);
+}
+
+/**
+ * 
+ * Updates the status to `published` of the editor document linked to a given versioned regulatory statement.
+ * 
+ * @param {string} versionedRegulatoryStatementUri The URI of the versioned regulatory statement
+ */
+export async function updateStatusOfLinkedEditorDocument(versionedRegulatoryStatementUri) {
+  const editorDocumentQuery = await query(`
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    SELECT ?editorDocument WHERE  {
+    ${sparqlEscapeUri(versionedRegulatoryStatementUri)} a ext:VersionedReglementaireBijlage;
+        ext:reglementaireBijlage ?editorDocument.
+    }
+  `);
+  if (!editorDocumentQuery.results.bindings.length)
+    throw new Error('Editor document not found for versioned reglementaire bijlage ' + versionedRegulatoryStatementUri);
+  const editorDocumentUri =  editorDocumentQuery.results.bindings[0].editorDocument.value;
+  await update(`
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    DELETE {
+      ${sparqlEscapeUri(editorDocumentUri)} ext:editorDocumentStatus ?status
+    } INSERT {
+      ${sparqlEscapeUri(editorDocumentUri)} ext:editorDocumentStatus ${sparqlEscapeUri(DOCUMENT_PUBLISHED_STATUS)}
+    } WHERE {
+      ${sparqlEscapeUri(editorDocumentUri)} ext:editorDocumentStatus ?status
+    }
+  `);
+}
+
+// export async function getLinkedRegulatoryStatements(treatmentUri){
+//   const linkedStatementsQuery = await query(`
+//     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+//     SELECT ?regulatoryStatementContainer WHERE  {
+//     ${sparqlEscapeUri(treatmentUri)} ext:hasDocumentContainer ?container .
+//     ?container ext:currentVersion ?hasCurrentVersion .
+//     ?regulatoryStatementContainer dct:isPartOf ?currentVersion .
+//     }
+//   `);
+//   return linkedStatementsQuery.results.bindings.map((binding) => binding.regulatoryStatementContainer.value);
+// }

--- a/support/regulatory-statement-utils.js
+++ b/support/regulatory-statement-utils.js
@@ -61,8 +61,8 @@ export async function updateStatusOfLinkedEditorDocument(versionedRegulatoryStat
   const editorDocumentQuery = await query(`
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     SELECT ?editorDocument WHERE  {
-    ${sparqlEscapeUri(versionedRegulatoryStatementUri)} a ext:VersionedReglementaireBijlage;
-        ext:reglementaireBijlage ?editorDocument.
+    ${sparqlEscapeUri(versionedRegulatoryStatementUri)} a ext:VersionedRegulatoryStatement;
+        ext:regulatoryStatement ?editorDocument.
     }
   `);
   if (!editorDocumentQuery.results.bindings.length)

--- a/support/resource-utils.js
+++ b/support/resource-utils.js
@@ -1,0 +1,25 @@
+// @ts-ignore
+import { query, sparqlEscapeString, sparqlEscapeUri } from 'mu';
+
+
+export async function getUri(uuid){
+  const queryResult = await query(
+    `PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+     SELECT * WHERE {
+       ?uri <http://mu.semte.ch/vocabularies/core/uuid> ${sparqlEscapeString( uuid )}
+     }`);
+  if (!queryResult.results.bindings.length)
+    throw new Error('URI not found for supplied uuid' + uuid);
+  return queryResult.results.bindings[0].uri;
+}
+
+export async function getUuid(uri){
+  const queryResult = await query(
+    `PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+     SELECT * WHERE {
+       ${sparqlEscapeUri(uri)} <http://mu.semte.ch/vocabularies/core/uuid> ?uuid
+     }`);
+  if (!queryResult.results.bindings.length)
+    throw new Error('URI not found for supplied URI' + uri);
+  return queryResult.results.bindings[0].uuid;
+}

--- a/support/resource-utils.js
+++ b/support/resource-utils.js
@@ -10,7 +10,7 @@ export async function getUri(uuid){
      }`);
   if (!queryResult.results.bindings.length)
     throw new Error('URI not found for supplied uuid' + uuid);
-  return queryResult.results.bindings[0].uri;
+  return queryResult.results.bindings[0].uri.value;
 }
 
 export async function getUuid(uri){
@@ -21,5 +21,5 @@ export async function getUuid(uri){
      }`);
   if (!queryResult.results.bindings.length)
     throw new Error('URI not found for supplied URI' + uri);
-  return queryResult.results.bindings[0].uuid;
+  return queryResult.results.bindings[0].uuid.value;
 }

--- a/support/sign-document.js
+++ b/support/sign-document.js
@@ -2,6 +2,7 @@
 import { update, sparqlEscapeUri, sparqlEscapeString, query } from 'mu';
 import { prefixMap } from "./prefixes";
 import { createHash } from 'crypto';
+import { getFileContentForUri } from './file-utils';
 
 // Create a hash for the signed - or public resource based on:
 
@@ -21,10 +22,12 @@ async function generateStringToHash(versionedUri, contentPredicate, sessionId, n
     ${prefixMap.get("sign").toSparqlString()}
     ${prefixMap.get("publicationStatus").toSparqlString()}
     ${prefixMap.get("dct").toSparqlString()}
+    ${prefixMap.get('prov').toSparqlString()}
+    ${prefixMap.get('nie').toSparqlString()}
 
-    SELECT DISTINCT ?content ?userUri WHERE{
-      ${sparqlEscapeUri(versionedUri)}
-        ${contentPredicate} ?content.
+    SELECT DISTINCT ?content ?fysicalFileUri ?userUri WHERE{
+      OPTIONAL { ${sparqlEscapeUri(versionedUri)} ${contentPredicate} ?content. }
+      OPTIONAL { ${sparqlEscapeUri(versionedUri)} prov:generated/^nie:dataSource ?fysicalFileUri. }
       ${sparqlEscapeUri(sessionId)}
         muSession:account/^foaf:account ?userUri.
     }
@@ -33,9 +36,18 @@ async function generateStringToHash(versionedUri, contentPredicate, sessionId, n
   try {
     const result = await query(queryString);
 
+    const binding = result.results.bindings[0];
+    let content;
+    if (binding.content) {
+      content = binding.content.value;
+    }
+    else {
+      content = await getFileContentForUri(binding.fysicalFileUri.value);
+    }
+
     const stringToHash =
       // the full text content
-      result.results.bindings[0].content.value +
+      content +
       // the uri of the person publishing/signing
       result.results.bindings[0].userUri.value +
       // the created date of the resource

--- a/support/sign-document.js
+++ b/support/sign-document.js
@@ -25,9 +25,9 @@ async function generateStringToHash(versionedUri, contentPredicate, sessionId, n
     ${prefixMap.get('prov').toSparqlString()}
     ${prefixMap.get('nie').toSparqlString()}
 
-    SELECT DISTINCT ?content ?fysicalFileUri ?userUri WHERE{
+    SELECT DISTINCT ?content ?physicalFileUri ?userUri WHERE{
       OPTIONAL { ${sparqlEscapeUri(versionedUri)} ${contentPredicate} ?content. }
-      OPTIONAL { ${sparqlEscapeUri(versionedUri)} prov:generated/^nie:dataSource ?fysicalFileUri. }
+      OPTIONAL { ${sparqlEscapeUri(versionedUri)} prov:generated/^nie:dataSource ?physicalFileUri. }
       ${sparqlEscapeUri(sessionId)}
         muSession:account/^foaf:account ?userUri.
     }
@@ -42,7 +42,7 @@ async function generateStringToHash(versionedUri, contentPredicate, sessionId, n
       content = binding.content.value;
     }
     else {
-      content = await getFileContentForUri(binding.fysicalFileUri.value);
+      content = await getFileContentForUri(binding.physicalFileUri.value);
     }
 
     const stringToHash =


### PR DESCRIPTION
This PR includes support for signing and publishing regulatory statements linked to an agendapoint treatment.
It does the following:
- When a treatment is signed, the latest versions of all the linked regulatory statements are also signed.
- When a treatment is published, the latest versions of all the linked regulatory statements are also published.

For each of the regulatory statements, it also creates an `versioned-regulatory-statement` when it is signed/published.

Additionally, this PR includes changes https://github.com/lblod/notulen-prepublish-service/pull/75. Versioned regulatory statements are stored in files.

This PR is a solution to https://binnenland.atlassian.net/browse/GN-3726?atlOrigin=eyJpIjoiZWU5Y2IyOTk1YzkyNGYyNjhlZDM4ZmIyNWM5YzRjMWMiLCJwIjoiaiJ9. 