### PR TITLE
GN-4441 Remove template comments from anything requested

### DIFF
--- a/support/editor-document.js
+++ b/support/editor-document.js
@@ -61,8 +61,6 @@ class EditorDocument {
 
   _removeTemplateComments() {
     const dom = this.getDom();
-    // clear dom as we'll change the content
-    this.dom = undefined;
     const comments = [
       ...dom.window.document.querySelectorAll(
         `div[typeof='${prefixMap.get('ext').name}:TemplateComment'`
@@ -73,6 +71,7 @@ class EditorDocument {
     ];
     comments.forEach((comment) => comment.remove());
     this.content = dom.window.document.body.innerHTML;
+    this.resetDom();
   }
 
   resetDom() {

--- a/support/editor-document.js
+++ b/support/editor-document.js
@@ -7,14 +7,23 @@ import { query, sparqlEscapeString, sparqlEscapeUri } from 'mu';
 import jsdom from 'jsdom';
 import { PUBLISHER_TEMPLATES } from './setup-handlebars';
 import { IS_FINAL } from './constants';
+import { prefixMap } from './prefixes';
 
+/**
+ * removeTemplateComments: remove all nodes that are a template comment. This should be done for
+ * anything that is not being edited.
+ */
 class EditorDocument {
   constructor(content) {
     this.content = undefined;
     this.context = {};
     this.uri = undefined;
+    this.removeTemplateComments = true;
     for (var key in content) {
       this[key] = content[key];
+    }
+    if(this.removeTemplateComments){
+      this._removeTemplateComments();
     }
   }
 
@@ -50,6 +59,16 @@ class EditorDocument {
     }
   }
 
+  _removeTemplateComments() {
+    const dom = this.getDom();
+    // clear dom as we'll change the content
+    this.dom = undefined;
+    const comments = [...dom.window.document.querySelectorAll(`div[typeof='${prefixMap.get("ext").name}:TemplateComment'`),
+    ...dom.window.document.querySelectorAll(`div[typeof='${prefixMap.get("ext").uri}TemplateComment'`)]
+    comments.forEach((comment) => comment.remove());
+    this.content = dom.window.document.body.innerHTML;
+  }
+
   resetDom() {
     this.dom = undefined;
     this.topDomNode = undefined;
@@ -80,6 +99,7 @@ async function editorDocumentFromUuid(uuid, attachments, previewType) {
             )}
      }`
   );
+  
   if (queryResult.results.bindings.length === 0) {
     console.log(`No content found for EditorDocument ${uuid} returning null`);
     return null;

--- a/support/editor-document.js
+++ b/support/editor-document.js
@@ -22,7 +22,7 @@ class EditorDocument {
     for (var key in content) {
       this[key] = content[key];
     }
-    if(this.removeTemplateComments){
+    if (this.removeTemplateComments) {
       this._removeTemplateComments();
     }
   }
@@ -63,8 +63,14 @@ class EditorDocument {
     const dom = this.getDom();
     // clear dom as we'll change the content
     this.dom = undefined;
-    const comments = [...dom.window.document.querySelectorAll(`div[typeof='${prefixMap.get("ext").name}:TemplateComment'`),
-    ...dom.window.document.querySelectorAll(`div[typeof='${prefixMap.get("ext").uri}TemplateComment'`)]
+    const comments = [
+      ...dom.window.document.querySelectorAll(
+        `div[typeof='${prefixMap.get('ext').name}:TemplateComment'`
+      ),
+      ...dom.window.document.querySelectorAll(
+        `div[typeof='${prefixMap.get('ext').uri}TemplateComment'`
+      ),
+    ];
     comments.forEach((comment) => comment.remove());
     this.content = dom.window.document.body.innerHTML;
   }
@@ -99,7 +105,7 @@ async function editorDocumentFromUuid(uuid, attachments, previewType) {
             )}
      }`
   );
-  
+
   if (queryResult.results.bindings.length === 0) {
     console.log(`No content found for EditorDocument ${uuid} returning null`);
     return null;


### PR DESCRIPTION
### Overview
Remove template from every editor document that is requested. This is the desired function: template comments are only needed when filling in a document and should be hidden when viewing a preview and signing/publishing a document.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4441
[frontend-gelinkt-notuleren PR #545](https://github.com/lblod/frontend-gelinkt-notuleren/pull/545)

### Setup
1. checkout frontend GN https://github.com/lblod/frontend-gelinkt-notuleren/pull/545
2. use the dev version of this service in your app-gelinkt-notuleren backend. Do this by changing the preimporter in e.g. docker-compose.override.yml. See https://github.com/lblod/notulen-prepublish-service#development-and-testing
3. run the backend and connect frontend...


### How to test/reproduce
Template comments should not be shown anywhere in GN, except when actually editing a document. Check if any places in GN still show them where they shouldn't.
Note: the frontend change will hide them via CSS. The service change *removes* them. Template comments should not exist anymore on documents that can't be edited anymore.

### Challenges/uncertainties
The change was done in the editorDocument class instead of in the places where an editorDocument was created. This to avoid having to remember to add it when adding new functionality. In essence the template comment should never be part of anything in the prepublish service.
Not 100% certain if this is the best place though.
