### PR TITLE
Optionally select file or content for signed resources

### DIFF
--- a/models/signed-resource.js
+++ b/models/signed-resource.js
@@ -15,7 +15,6 @@ export default class SignedResource {
       BIND(${sparqlEscapeUri(uri)} as ?uri)
         ?uri a sign:SignedResource;
              mu:uuid ?uuid;
-             sign:text ?html;
              sign:hashValue ?hashValue;
              sign:hashAlgorithm ?hashAlgorithm;
              dct:created ?created;
@@ -27,6 +26,11 @@ export default class SignedResource {
         ?blockchainStatus mu:uuid ?blockchainStatusUuid.
         ?signatory mu:uuid ?signatoryUuid.
         
+        {
+          { ?uri sign:text ?html. }
+          UNION
+          { ?uri prov:generated ?file. }
+        }
         OPTIONAL { ?uri ext:deleted ?deleted. }
         OPTIONAL { 
            ?uri ext:signsAgenda ?agenda.
@@ -71,6 +75,7 @@ export default class SignedResource {
     uri,
     uuid,
     html,
+    file,
     hashValue,
     hashAlgorithm,
     created,
@@ -92,7 +97,8 @@ export default class SignedResource {
     return new SignedResource({
       uri: uri.value,
       uuid: uuid.value,
-      html: html.value,
+      html: html?.value,
+      file: file?.value,
       hashValue: hashValue.value,
       hashAlgorithm: hashAlgorithm.value,
       created: created.value,
@@ -117,6 +123,7 @@ export default class SignedResource {
     uri,
     uuid,
     html,
+    file,
     hashValue,
     hashAlgorithm,
     created,
@@ -138,6 +145,7 @@ export default class SignedResource {
     this.uuid = uuid;
     this.uri = uri;
     this.html = html;
+    this.file = file;
     this.signatory = signatory;
     this.created = created;
     this.signatoryRole = signatoryRole;
@@ -213,6 +221,7 @@ export default class SignedResource {
         attributes: {
           uri: this.uri,
           content: this.html,
+          file: this.file,
           'hash-value': this.hashValue,
           'created-on': this.created,
           deleted: this.deleted,

--- a/support/pre-importer.js
+++ b/support/pre-importer.js
@@ -97,6 +97,8 @@ async function handleVersionedResource(
         .join(' ')
     : '';
   const content = await getVersionedContent(versionedUri, contentPredicate);
+  // This creates a new file each time, even if getVersionedContent has just retrieved it from a
+  // file. This is to make handling deletes and document changes easier.
   const fileMetadata = await persistContentToFile(content);
   const logicalFileUri = await writeFileMetadataToDb(fileMetadata);
 


### PR DESCRIPTION
The query for signed resources was assuming that the content was stored directly in the DB, but since that has moved to a file, we need to handle both possibilities. Made this optional and updated the docs.

This alone prevents the [the issue](https://github.com/lblod/frontend-gelinkt-notuleren/issues/639) with signing extracts, but the optional content breaks the detail view in the 'publication actions' page for deleted signatures. The fix for that will need to be across other services.

For how to reproduce, see the issue in Jira: https://binnenland.atlassian.net/browse/GN-4769

Part of https://github.com/lblod/frontend-gelinkt-notuleren/issues/639