### PR TITLE
Switch template version to semtech version 1.5.0-beta.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvdk/mu-javascript-template
+FROM semtech/mu-javascript-template:1.5.0-beta.3
 LABEL maintainer=info@redpencil.io
 # disable logging of sparql queries for performance
 ENV LOG_SPARQL_ALL "false"


### PR DESCRIPTION
The nearest common ancestor of the nvdk fork and upstream master is 01e6cbad35f4b5677b16831a11c43fa552228cfb which is just before the release of v1.5.0-beta.3, so move to that tag, to be clearly on a mainline version