### PR TITLE
Fix typo in mandatee list template

### DIFF
--- a/support/templates/partials/mandatee-list.hbs
+++ b/support/templates/partials/mandatee-list.hbs
@@ -29,7 +29,7 @@
                 <span property="foaf:familyName" content={{this.familyName}}>{{this.familyName}} </span>
               </span>
               {{#if ../includeRole}}
-                (<span property="org:holds" typeof="mandaat:Mandaat" resource="{{this.positionUri}}"><span property="org:role" typeof="skos:Concept" resource="{{this.roleUri}}"><span property="skos:prefLabel" content={{this.role}}>{{this.role}}</span></span></span>)
+                (<span property="org:holds" typeof="mandaat:Mandaat" resource="{{this.positionUri}}"><span property="org:role" typeof="skos:Concept" resource="{{this.roleUri}}"><span property="skos:prefLabel" content="{{this.role}}">{{this.role}}</span></span></span>)
               {{/if}}
             </li>
           {{/each}}


### PR DESCRIPTION
Fixes GN-4835, the attribute being inserted without quotes caused that every single word was interpreted correctly but failed when there was an space, that's the cause it went unnoticed for 3+ years