### PR TITLE
Fix issue with predicate filtering to extract decisions

### DIFF
--- a/models/decision.js
+++ b/models/decision.js
@@ -12,7 +12,9 @@ export default class Decision {
       const decisionUris = triples
         .filter(
           (t) =>
-            t.predicate === 'a' &&
+            (t.predicate === 'a' ||
+              t.predicate ===
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type') &&
             t.object === 'http://data.vlaanderen.be/ns/besluit#Besluit'
         )
         .map((b) => b.subject);
@@ -37,7 +39,11 @@ export default class Decision {
     );
     const description = descriptionTriple?.object;
     const types = triples
-      .filter((t) => t.predicate === 'a')
+      .filter(
+        (t) =>
+          t.predicate === 'a' ||
+          t.predicate === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+      )
       .map((type) => type.object);
     const uri = triples[0].subject;
     return new Decision({ title, description, types, uri });


### PR DESCRIPTION
### Overview
This PR includes a fix to the code responsible for extracting decisions of a document. It takes into account that the rdf type predicate can be represented by 'a' as well as 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'.

##### connected issues and PRs:
None


### Setup
Test this PR in combination with https://github.com/lblod/app-gelinkt-notuleren.
```yaml
prepublish:
    environment:
      NODE_ENV: "development"
    volumes:
      - <path-to-this-service>:/app/
```

### How to test/reproduce
- Start the application
- Login and create a new meeting with a new agendapoint
- Insert a decision in the agendapoint
- Open up the meeting publishing page and select 'Decision List'
- The decision list should correctly show up (the decisions should be found), no error should be shown.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
