### PR TITLE
Handle logical file uris with no related physical file information

### DIFF
--- a/models/versioned-notulen.js
+++ b/models/versioned-notulen.js
@@ -17,7 +17,7 @@ export default class VersionedNotulen {
     ${prefixMap.get('prov').toSparqlString()}
     ${prefixMap.get('nie').toSparqlString()}
 
-    SELECT ?uri ?html
+    SELECT ?uri ?html ?fileUri
     WHERE {
       ?uri a ext:VersionedNotulen;
                   ext:notulenKind ${sparqlEscapeString(kind)}.
@@ -55,7 +55,7 @@ export default class VersionedNotulen {
    * @property {string} kind
    * @property {Meeting} meeting
    * @property {string} html
-   * @property {[]} publicTreatments
+   * @property {PublicTreatment[]} publicTreatments
    */
   /**
    * create a new versioned notulen

--- a/support/notulen-utils.js
+++ b/support/notulen-utils.js
@@ -112,10 +112,12 @@ export async function ensureVersionedNotulen(
   publicTreatments = []
 ) {
   let versionedNotulen = await VersionedNotulen.query({ meeting, kind });
+  let notulenUri;
   if (versionedNotulen) {
     console.log(
       `Reusing versioned notulen ${versionedNotulen.uri} of kind ${kind}`
     );
+    notulenUri = versionedNotulen.uri;
     if (versionedNotulen.html) {
       return versionedNotulen.uri;
     } else {
@@ -147,6 +149,7 @@ export async function ensureVersionedNotulen(
     html = constructHtmlForMeetingNotesFromData(data);
   }
   versionedNotulen = await VersionedNotulen.create({
+    notulenUri,
     meeting,
     html,
     kind,

--- a/support/notulen-utils.js
+++ b/support/notulen-utils.js
@@ -111,42 +111,48 @@ export async function ensureVersionedNotulen(
   kind,
   publicTreatments = []
 ) {
-  const versionedNotulen = await VersionedNotulen.query({ meeting, kind });
+  let versionedNotulen = await VersionedNotulen.query({ meeting, kind });
   if (versionedNotulen) {
     console.log(
       `Reusing versioned notulen ${versionedNotulen.uri} of kind ${kind}`
     );
-    return versionedNotulen.uri;
+    if (versionedNotulen.html) {
+      return versionedNotulen.uri;
+    } else {
+      console.warn(
+        `Versioned notulen for ${meeting.uri} (kind ${kind}) has no content, recreating...`
+      );
+    }
   } else {
     console.log(
       `Creating a new versioned notulen of kind ${kind} for ${meeting.uri}`
     );
-    let html;
-    if (kind === NOTULEN_KIND_FULL) {
-      const data = await buildDataForMeetingNotes({
-        meeting,
-        treatments,
-        previewType: IS_FINAL,
-        allPublic: true,
-      });
-      html = constructHtmlForMeetingNotesFromData(data);
-    } else {
-      const data = await buildDataForMeetingNotes({
-        meeting,
-        treatments,
-        previewType: IS_FINAL,
-        publicTreatments,
-      });
-      html = constructHtmlForMeetingNotesFromData(data);
-    }
-    const versionedNotulen = await VersionedNotulen.create({
+  }
+  let html;
+  if (kind === NOTULEN_KIND_FULL) {
+    const data = await buildDataForMeetingNotes({
       meeting,
-      html,
-      kind,
+      treatments,
+      previewType: IS_FINAL,
+      allPublic: true,
+    });
+    html = constructHtmlForMeetingNotesFromData(data);
+  } else {
+    const data = await buildDataForMeetingNotes({
+      meeting,
+      treatments,
+      previewType: IS_FINAL,
       publicTreatments,
     });
-    return versionedNotulen.uri;
+    html = constructHtmlForMeetingNotesFromData(data);
   }
+  versionedNotulen = await VersionedNotulen.create({
+    meeting,
+    html,
+    kind,
+    publicTreatments,
+  });
+  return versionedNotulen.uri;
 }
 
 export async function generateNotulenPreview(

--- a/support/pre-importer.js
+++ b/support/pre-importer.js
@@ -58,13 +58,12 @@ async function getVersionedContent(uri, contentPredicate) {
     const binding = result.results.bindings[0];
     if (binding.content) {
       return binding.content.value;
-    } else {
+    } else if (binding.physicalFileUri) {
       const content = await getFileContentForUri(binding.physicalFileUri.value);
       return content;
     }
-  } else {
-    throw 'could not retrieve content';
   }
+  throw new Error('could not retrieve content');
 }
 
 async function handleVersionedResource(


### PR DESCRIPTION
I'm not sure how, but we have some `ext:VersionedNotulen` in production, with a `prov:generated` logical file uri, but that logical file has no other triples linking to it, so there's therefore no way to find a physical file uri (if one exists), so no way to fetch the file. This handles this case by recreating a new file and storing it correctly.

This flow is close to the previous flow, but since we've fixed the query, we're actually now requesting the file contents twice, once on `VersionedNotulen.query()` and once on `signVersionedNotulen()`. I started refactoring this out, but think this larger change should wait and we should push out this smaller fix to production asap.