### PR TITLE
Custom votes where not supported on the decision list

### DIFF
--- a/support/templates/besluitenlijst-prepublish.hbs
+++ b/support/templates/besluitenlijst-prepublish.hbs
@@ -43,11 +43,6 @@
                 </p>
               </div>
             {{/if}}
-             {{#if (eq this.type "customVote")}}
-              <div typeof="http://data.lblod.info/vocabularies/gelinktnotuleren/AangepasteStemming" resource="{{this.uri}}" property="http://data.lblod.info/vocabularies/gelinktnotuleren/heeftAangepasteStemming">
-                {{{this.content}}}
-              </div>
-            {{/if}}
           {{/each}}
         {{/if}}
         </div>

--- a/support/templates/besluitenlijst-prepublish.hbs
+++ b/support/templates/besluitenlijst-prepublish.hbs
@@ -31,16 +31,23 @@
         {{#if this.votes}}
           <h3>Stemmingen</h3>
           {{#each this.votes}}
-            <div class="c-template-content c-template-content--voting" typeof="http://data.vlaanderen.be/ns/besluit#Stemming" resource="{{this.uri}}" property="besluit:heeftStemming">
-              <p>
-                <strong>Onderwerp:</strong>
-                <span property="besluit:onderwerp">{{this.subject}}</span>,
-              </p>
-              <p>
-                <strong>Gevolg:</strong>
-                <span property="besluit:gevolg">{{this.result}}</span>
-              </p>
-            </div>
+            {{#if (eq this.type "standardVote")}}
+              <div class="c-template-content c-template-content--voting" typeof="http://data.vlaanderen.be/ns/besluit#Stemming" resource="{{this.uri}}" property="besluit:heeftStemming">
+                <p>
+                  <strong>Onderwerp:</strong>
+                  <span property="besluit:onderwerp">{{this.subject}}</span>,
+                </p>
+                <p>
+                  <strong>Gevolg:</strong>
+                  <span property="besluit:gevolg">{{this.result}}</span>
+                </p>
+              </div>
+            {{/if}}
+             {{#if (eq this.type "customVote")}}
+              <div typeof="http://data.lblod.info/vocabularies/gelinktnotuleren/AangepasteStemming" resource="{{this.uri}}" property="http://data.lblod.info/vocabularies/gelinktnotuleren/heeftAangepasteStemming">
+                {{{this.content}}}
+              </div>
+            {{/if}}
           {{/each}}
         {{/if}}
         </div>

--- a/support/templates/partials/mandatee-list.hbs
+++ b/support/templates/partials/mandatee-list.hbs
@@ -25,8 +25,8 @@
           {{#each mandatees}}
             <li class="au-c-template-list-inline__item" typeof="http://data.vlaanderen.be/ns/mandaat#Mandataris" resource="{{this.uri}}" property="{{../property}}">
               <span resource="{{this.personUri}}" property="mandaat:isBestuurlijkeAliasVan" typeof="person:Person">
-                <span property="persoon:gebruikteVoornaam" content={{this.name}}>{{this.name}}</span>
-                <span property="foaf:familyName" content={{this.familyName}}>{{this.familyName}} </span>
+                <span property="persoon:gebruikteVoornaam" content="{{this.name}}">{{this.name}}</span>
+                <span property="foaf:familyName" content="{{this.familyName}}">{{this.familyName}} </span>
               </span>
               {{#if ../includeRole}}
                 (<span property="org:holds" typeof="mandaat:Mandaat" resource="{{this.positionUri}}"><span property="org:role" typeof="skos:Concept" resource="{{this.roleUri}}"><span property="skos:prefLabel" content="{{this.role}}">{{this.role}}</span></span></span>)


### PR DESCRIPTION
My bad, I didn't know the voting results where included into the decision list and didn't test this case. It should be solved now.
For context, reported by GN-5278, when you had a custom voting in the meeting the decision list publication throwed an error.
