### PR TITLE
GN-5336: hide 'stemmingen' title when there are no standard votes

### DIFF
--- a/support/besluit-exporter.js
+++ b/support/besluit-exporter.js
@@ -44,13 +44,13 @@ async function addVotesToTreatment(treatment) {
   const standardVotes = await StandardVote.findAll({
     treatmentUri: treatment.uri,
   });
+
   const customVotes = await CustomVote.findAll({ treatmentUri: treatment.uri });
-  const votes = [...standardVotes, ...customVotes];
-  votes.sort((a, b) => a.position - b.position);
-  if (votes.length > 0) {
-    // this makes it easier to check if there are votes in the template
-    treatment.votes = votes;
-  }
+
+  standardVotes.sort((a, b) => a.position - b.position);
+  customVotes.sort((a, b) => a.position - b.position);
+  treatment.standardVotes = standardVotes;
+  treatment.customVotes = customVotes;
 }
 
 export function constructHtmlForDecisionList(meeting, treatments) {

--- a/support/templates/besluitenlijst-prepublish.hbs
+++ b/support/templates/besluitenlijst-prepublish.hbs
@@ -28,21 +28,19 @@
             <span property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept"></span>
           </div>
         {{/each}}
-        {{#if this.votes}}
+        {{#if this.standardVotes}}
           <h3>Stemmingen</h3>
-          {{#each this.votes}}
-            {{#if (eq this.type "standardVote")}}
-              <div class="c-template-content c-template-content--voting" typeof="http://data.vlaanderen.be/ns/besluit#Stemming" resource="{{this.uri}}" property="besluit:heeftStemming">
-                <p>
-                  <strong>Onderwerp:</strong>
-                  <span property="besluit:onderwerp">{{this.subject}}</span>,
-                </p>
-                <p>
-                  <strong>Gevolg:</strong>
-                  <span property="besluit:gevolg">{{this.result}}</span>
-                </p>
-              </div>
-            {{/if}}
+          {{#each this.standardVotes}}
+            <div class="c-template-content c-template-content--voting" typeof="http://data.vlaanderen.be/ns/besluit#Stemming" resource="{{this.uri}}" property="besluit:heeftStemming">
+              <p>
+                <strong>Onderwerp:</strong>
+                <span property="besluit:onderwerp">{{this.subject}}</span>,
+              </p>
+              <p>
+                <strong>Gevolg:</strong>
+                <span property="besluit:gevolg">{{this.result}}</span>
+              </p>
+            </div>
           {{/each}}
         {{/if}}
         </div>


### PR DESCRIPTION
### Overview
This PR ensures that the 'Stemmingen' section-title in a decision-list is hidden if there are no standard votes

##### connected issues and PRs:
[GN-5336](https://binnenland.atlassian.net/browse/GN-5336)

### Setup
Include this service in the GN stack, like so:
```yaml
prepublish:
    image: !reset null
    build: https://github.com/lblod/notulen-prepublish-service.git#GN-5336-stemmingen-header
```

### How to test/reproduce
- Start the stack
- Login and open a meeting
- Add a custom vote to an AP of the meeting
- Visit the 'besluitenlijst' prepublish screen
- Ensure that no voting-sections are included on any of the decisions. (not even the title 'Stemmingen')
- Visit the 'notulen' page. On this page, the custom voting should be visible.
- Add an AP with a standard voting
- Ensure that this voting is included on the 'besluitenlijst' prepublish screen

### Challenges/uncertainties
- I think it would be better to move the code responsible for loading the `votes` and `decisions` relationships to the `Treatment` class, in methods `loadVotes` and `loadDecisions` respectively. I did not do this yet, as I am first looking into improving the eslint/type-checking setup of this service.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
