### PR TITLE
Fix checking of user ids when limiting running tasks

### DIFF
--- a/models/task.js
+++ b/models/task.js
@@ -37,7 +37,7 @@ export class TaskError {
 }
 
 export default class Task {
-  static async create(meeting, type) {
+  static async create(meeting, type, userUri) {
     const id = uuid();
     const uri = `http://lblod.data.gift/tasks/${id}`;
     const created = Date.now();
@@ -56,6 +56,7 @@ export default class Task {
         dct:modified ${sparqlEscapeDateTime(created)};
         dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
         dct:type ${sparqlEscapeString(type)};
+        ${userUri ? `nuao:involves ${sparqlEscapeUri(userUri)};` : ''}
         nuao:involves ${sparqlEscapeUri(meeting.uri)}.
     }
   `;
@@ -72,6 +73,9 @@ export default class Task {
   }
 
   static async find(uuid) {
+    // If a userUri is included, this actually finds 2 results as there are 2 `nuao:involves`
+    // triples. This doesn't cause any side effects though as nothing relies on this value here and
+    // all other data is the same.
     const result = await query(`
      ${prefixMap.get('mu').toSparqlString()}
      ${prefixMap.get('nuao').toSparqlString()}

--- a/support/query-utils.js
+++ b/support/query-utils.js
@@ -79,9 +79,9 @@ export async function fetchCurrentUser(sessionId) {
     ${sparqlEscapeUri(sessionId)} muSession:account/^foaf:account ?userUri.
   }
   `;
-  const result = query(q);
+  const result = await query(q);
   if (result?.results?.bindings.length === 1) {
-    return result.results.bindings.userUri.value;
+    return result.results.bindings[0].userUri.value;
   } else {
     return null;
   }

--- a/support/task-utils.js
+++ b/support/task-utils.js
@@ -10,7 +10,7 @@ export async function ensureTask(meeting, taskType, userUri) {
     ? await Task.query({ meetingUri: meeting.uri, type: taskType, userUri })
     : await Task.query({ meetingUri: meeting.uri, type: taskType });
   if (!task) {
-    task = await Task.create(meeting, taskType);
+    task = await Task.create(meeting, taskType, userUri);
   }
   return task;
 }


### PR DESCRIPTION
The code in the prepublisher which is intended to limit each user to only one concurrent signing or publishing task (per type and meeting) was in fact not including the user URI correctly, so was always just limiting to one task of each type per meeting. It’s unclear if this caused any issues for users.

Jira ticket: https://binnenland.atlassian.net/browse/GN-5358