### PR TITLE
Correctly target besluit container

### DIFF
--- a/support/editor-document.js
+++ b/support/editor-document.js
@@ -185,7 +185,7 @@ function appendAttachmentsToDocument(
       previewType
     );
     const decisionContainer = dom.window.document.querySelector(
-      `[resource="${decisionKey}"]`
+      `[about="${decisionKey}"]`
     );
     if (decisionContainer) {
       decisionContainer.insertAdjacentHTML('beforeend', htmlToAdd);


### PR DESCRIPTION
The rdfa produced by the editor changed and the besluit container no longer has a resource property.
This caused the bug described in GN-5450.