### PR TITLE
Add decision linking information to treatment HTML

### DIFF
--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -7,7 +7,10 @@ steps:
       platforms: linux/amd64
       # Can enable arm64 when moving to mu-javascript-template version >1.8
       # platforms: linux/amd64, linux/arm64
-    secrets: [ docker_username, docker_password ]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
   branch: master
   event: push

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -7,7 +7,10 @@ steps:
       platforms: linux/amd64
       # Can enable arm64 when moving to mu-javascript-template version >1.8
       # platforms: linux/amd64, linux/arm64
-    secrets: [ docker_username, docker_password ]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
   event: tag
   ref: refs/tags/v*

--- a/support/templates/partials/treatment.hbs
+++ b/support/templates/partials/treatment.hbs
@@ -103,6 +103,10 @@
     </div>
   {{/if}}
   <div class="c-template-content c-template-content--treatment">
+    {{#each this.decisions}}
+      <span property="http://www.w3.org/ns/prov#generated"
+            resource="{{this.uri}}"></span>
+    {{/each}}
     {{{content}}}
   </div>
 </div>


### PR DESCRIPTION
The old approach was to have the decision node contain RDFa which would result in it being linked to the treatment. This is no longer the case, so instead we go for an explicit linking in the treatment output document.

I didn't alter the tests yet as I see that [running them on CI is non-trivial](https://github.com/lblod/notulen-prepublish-service/pull/126). I'll maybe take a look later as we can perhaps either use the PR's approach or that of the more recent JS templates.