### PR TITLE
Validate signature and publication

### DIFF
--- a/support/pre-importer.js
+++ b/support/pre-importer.js
@@ -207,7 +207,7 @@ async function checkValidSignature(versionedUri, sessionId) {
     }
   `;
   const queryResult = await query(validationQuery);
-  return !queryResult.results.bindings[0]?.invalid.value;
+  return queryResult.results.bindings[0]?.invalid.value !== '1';
 }
 
 async function checkValidPublication(versionedUri) {

--- a/support/pre-importer.js
+++ b/support/pre-importer.js
@@ -85,6 +85,19 @@ async function handleVersionedResource(
   customContentPredicate,
   attachments
 ) {
+  if (type === 'signature') {
+    const isValidSignature = await checkValidSignature(versionedUri, sessionId);
+    if (!isValidSignature)
+      throw new Error(
+        `The resource with uri ${versionedUri} cannot be signed by ${sessionId}`
+      );
+  } else {
+    const isValidPublication = await checkValidPublication(versionedUri);
+    if (!isValidPublication)
+      throw new Error(
+        `The resource with uri ${versionedUri} cannot be publised as it has been published before`
+      );
+  }
   const now = new Date();
   const newResourceUuid = uuid();
   const resourceType =
@@ -158,6 +171,65 @@ async function handleVersionedResource(
     'sha256'
   );
   return newResourceUri;
+}
+
+async function checkValidSignature(versionedUri, sessionId) {
+  const validationQuery = `
+  ${prefixMap['dct'].toSparqlString()}
+   ${prefixMap['sign'].toSparqlString()}
+   ${prefixMap['muSession'].toSparqlString()}
+   ${prefixMap['foaf'].toSparqlString()}
+   ${prefixMap['ext'].toSparqlString()}
+    SELECT ?invalid WHERE {
+      OPTIONAL {
+        ?a a sign:SignedResource;
+          dct:subject ${sparqlEscapeUri(versionedUri)}.
+        ?b a sign:SignedResource;
+          dct:subject ${sparqlEscapeUri(versionedUri)}.
+        FILTER(?a != ?b)
+        FILTER NOT EXISTS {
+          ?a ext:deleted "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.
+        }
+        FILTER NOT EXISTS {
+          ?b ext:deleted "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.
+        }
+      }
+      OPTIONAL {
+        ?c a sign:SignedResource; 
+           dct:subject ${sparqlEscapeUri(versionedUri)};
+          sign:signatory ?userUri.
+        FILTER NOT EXISTS {
+          ?c ext:deleted "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.
+        }
+      }
+      BIND( BOUND(?a) || BOUND(?c) AS ?invalid)
+      ${sparqlEscapeUri(sessionId)} muSession:account/^foaf:account ?userUri.
+    }
+  `;
+  const queryResult = await query(validationQuery);
+  return !queryResult.results.bindings[0]?.invalid.value;
+}
+
+async function checkValidPublication(versionedUri) {
+  const validationQuery = `
+  ${prefixMap['dct'].toSparqlString()}
+   ${prefixMap['sign'].toSparqlString()}
+   ${prefixMap['muSession'].toSparqlString()}
+   ${prefixMap['foaf'].toSparqlString()}
+   ${prefixMap['ext'].toSparqlString()}
+    SELECT ?invalid WHERE {
+      OPTIONAL {
+        ?a a sign:PublishedResource;
+          dct:subject ${sparqlEscapeUri(versionedUri)}.
+        FILTER NOT EXISTS {
+          ?a ext:deleted "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.
+        }
+      }
+      BIND( BOUND(?a) AS ?invalid)
+    }
+  `;
+  const queryResult = await query(validationQuery);
+  return queryResult.results.bindings[0]?.invalid.value !== '1';
 }
 
 export { hackedSparqlEscapeString, handleVersionedResource, cleanupTriples };


### PR DESCRIPTION
Validate that the user can sign or publish the resource.
In signing you cannot have sign the resource previously and the resource cannot have other 2 active signatures.
In publishing there can't be another published resource active.
I throwed an error, in the frontend the handler is not very good as it just show an error page without any feedback, but I think this is okay as it should never happen realistically