### PR TITLE
Block concurrent signing

### DIFF
--- a/models/task.js
+++ b/models/task.js
@@ -11,6 +11,8 @@ import {
 } from 'mu';
 import { v1 as uuid } from 'uuid';
 import { prefixMap } from '../support/prefixes.js';
+import AppError from '../support/error-utils.js';
+/** @import { BindingObject } from 'mu' */
 
 export const TASK_TYPE_SIGNING_DECISION_LIST = 'decisionListSignature';
 export const TASK_TYPE_PUBLISHING_DECISION_LIST = 'decisionListPublication';
@@ -75,10 +77,11 @@ export default class Task {
     });
   }
 
+  /**
+   * @param {string} uuid
+   * @returns {Promise<Task>}
+   */
   static async find(uuid) {
-    // If a userUri is included, this actually finds 2 results as there are 2 `nuao:involves`
-    // triples. This doesn't cause any side effects though as nothing relies on this value here and
-    // all other data is the same.
     const result = await query(`
      ${prefixMap['mu'].toSparqlString()}
      ${prefixMap['nuao'].toSparqlString()}
@@ -86,6 +89,7 @@ export default class Task {
      ${prefixMap['dct'].toSparqlString()}
      ${prefixMap['adms'].toSparqlString()}
      ${prefixMap['oslc'].toSparqlString()}
+     ${prefixMap['besluit'].toSparqlString()}
      SELECT ?uri ?uuid ?type ?involves ?status ?modified ?created ?error ?errorId ?errorMessage WHERE {
        BIND(${sparqlEscapeString(uuid)} AS ?uuid)
        ?uri a task:Task;
@@ -96,8 +100,9 @@ export default class Task {
             nuao:involves ?involves;
             dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
             adms:status ?status.
+        ?involves a besluit:Zitting.
        OPTIONAL {
-	 ?uri task:error ?error.
+         ?uri task:error ?error.
          ?error mu:uuid ?errorId.
          ?error oslc:message ?errorMessage.
        }
@@ -105,9 +110,20 @@ export default class Task {
    `);
     if (result.results.bindings.length) {
       return Task.fromBinding(result.results.bindings[0]);
-    } else return null;
+    }
+    throw new AppError(404, `task with id ${uuid} was not found`);
   }
 
+  /**
+   * @typedef {object} QueryArgs
+   * @property {string} meetingUri
+   * @property {string} type
+   * @property {string | null} [userUri]
+   */
+  /**
+   * @param {QueryArgs} args
+   * @returns {Promise<Task | null>}
+   */
   static async query({ meetingUri, type, userUri = null }) {
     const result = await query(`
      ${prefixMap['mu'].toSparqlString()}
@@ -116,7 +132,7 @@ export default class Task {
      ${prefixMap['dct'].toSparqlString()}
      ${prefixMap['adms'].toSparqlString()}
      ${prefixMap['oslc'].toSparqlString()}
-     SELECT ?uri ?uuid ?type ?involves ?status ?modified ?created ?error ?errorId ?errorMessage WHERE {
+     SELECT ?uri ?uuid ?status ?modified ?created ?error ?errorId ?errorMessage WHERE {
        ?uri a task:Task;
             mu:uuid ?uuid;
             dct:type ${sparqlEscapeString(type)};
@@ -127,7 +143,7 @@ export default class Task {
             adms:status ?status.
 
        OPTIONAL {
-	 ?uri task:error ?error.
+         ?uri task:error ?error.
          ?error mu:uuid ?errorId.
          ?error oslc:message ?errorMessage.
        }
@@ -137,12 +153,16 @@ export default class Task {
     if (result.results.bindings.length) {
       return Task.fromBinding({
         ...result.results.bindings[0],
-        type: type,
-        involves: meetingUri,
+        type: { type: 'string', value: type },
+        involves: { type: 'uri', value: meetingUri },
       });
     } else return null;
   }
 
+  /**
+   * @param {BindingObject} binding
+   * @returns {Task}
+   */
   static fromBinding(binding) {
     let taskError = null;
     if (binding.error?.value) {

--- a/models/task.js
+++ b/models/task.js
@@ -1,6 +1,3 @@
-// @ts-nocheck
-// @ts-strict-ignore
-
 import {
   query,
   sparqlEscapeDateTime,
@@ -12,6 +9,7 @@ import {
 import { v1 as uuid } from 'uuid';
 import { prefixMap } from '../support/prefixes.js';
 import AppError from '../support/error-utils.js';
+/** @import Meeting from './meeting' */
 /** @import { BindingObject } from 'mu' */
 
 export const TASK_TYPE_SIGNING_DECISION_LIST = 'decisionListSignature';
@@ -27,21 +25,37 @@ export const TASK_STATUS_SUCCESS =
 export const TASK_STATUS_RUNNING =
   'http://lblod.data.gift/besluit-publicatie-melding-statuses/ongoing';
 export class TaskError {
+  /**
+   * @typedef {object} TaskErrorArgs
+   * @property {string} [id]
+   * @property {string} [uri]
+   * @property {string} message
+   */
+  /** @param {TaskErrorArgs} args */
   constructor({ id, uri, message }) {
     if (uri) {
       // we don't want to generate a new id if we got a uri, even if it's null
+      /** @type {string | undefined} */
       this.id = id;
+      /** @type {string} */
       this.uri = uri;
     } else {
       this.id = id ?? uuid();
       this.uri = `http://redpencil.data.gift/id/jobs/error/${this.id}`;
     }
 
+    /** @type {string} */
     this.message = message;
   }
 }
 
 export default class Task {
+  /**
+   * @param {Meeting} meeting
+   * @param {string} type
+   * @param {string} userUri
+   * @returns {Promise<Task>}
+   */
   static async create(meeting, type, userUri) {
     const id = uuid();
     const uri = `http://lblod.data.gift/tasks/${id}`;
@@ -164,7 +178,7 @@ export default class Task {
    * @returns {Task}
    */
   static fromBinding(binding) {
-    let taskError = null;
+    let taskError = undefined;
     if (binding.error?.value) {
       taskError = new TaskError({
         uri: binding.error.value,
@@ -185,15 +199,35 @@ export default class Task {
     });
   }
 
+  /**
+   * @typedef {object} TaskArgs
+   * @property {string} id
+   * @property {string} type
+   * @property {string} involves - The meeting that this task acts on
+   * @property {string} created
+   * @property {string} modified
+   * @property {string} status
+   * @property {string} uri
+   * @property {TaskError} [error]
+   */
+  /** @param {TaskArgs} taskArgs */
   constructor({ id, uri, created, status, modified, type, involves, error }) {
+    /** @type {string} */
     this.id = id;
+    /** @type {string} */
     this.type = type;
+    /** @type {string} - The meeting that this task acts on */
     this.involves = involves;
+    /** @type {string} */
     this.created = created;
+    /** @type {string} */
     this.modified = modified;
+    /** @type {string} */
     this.status = status;
+    /** @type {string} */
     this.uri = uri;
-    this.error = error;
+    /** @type {TaskError | null} */
+    this.error = error ?? null;
   }
 
   async updateStatus(status, reason) {

--- a/models/task.js
+++ b/models/task.js
@@ -7,6 +7,7 @@ import {
   update,
 } from 'mu';
 import { v1 as uuid } from 'uuid';
+import { DateTime } from 'luxon';
 import { prefixMap } from '../support/prefixes.js';
 import AppError from '../support/error-utils.js';
 /** @import Meeting from './meeting' */
@@ -51,9 +52,11 @@ export class TaskError {
 
 export default class Task {
   /**
+   * Creates a new task. If a running task of the same type for the same meeting already exists, it
+   * is created in the 'created' state, otherwise it is created in the 'running' state.
    * @param {Meeting} meeting
    * @param {string} type
-   * @param {string} userUri
+   * @param {string} [userUri]
    * @returns {Promise<Task>}
    */
   static async create(meeting, type, userUri) {
@@ -66,29 +69,41 @@ export default class Task {
      PREFIX    task: <http://redpencil.data.gift/vocabularies/tasks/>
      PREFIX    dct: <http://purl.org/dc/terms/>
      PREFIX    adms: <http://www.w3.org/ns/adms#>
-     INSERT DATA {
-        ${sparqlEscapeUri(uri)} a task:Task;
-        mu:uuid ${sparqlEscapeString(id)};
-        adms:status ${sparqlEscapeUri(TASK_STATUS_CREATED)};
-        task:numberOfRetries ${sparqlEscapeInt(0)};
-        dct:created ${sparqlEscapeDateTime(created)};
-        dct:modified ${sparqlEscapeDateTime(created)};
-        dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
-        dct:type ${sparqlEscapeString(type)};
-        ${userUri ? `nuao:involves ${sparqlEscapeUri(userUri)};` : ''}
-        nuao:involves ${sparqlEscapeUri(meeting.uri)}.
+     ${prefixMap['mu'].toSparqlString()}
+     ${prefixMap['nuao'].toSparqlString()}
+     ${prefixMap['task'].toSparqlString()}
+     ${prefixMap['dct'].toSparqlString()}
+     ${prefixMap['adms'].toSparqlString()}
+     ${prefixMap['xsd'].toSparqlString()}
+     ${prefixMap['ext'].toSparqlString()}
+     INSERT {
+       ${sparqlEscapeUri(uri)} a task:Task;
+         mu:uuid ${sparqlEscapeString(id)};
+         adms:status ?status;
+         task:numberOfRetries ${sparqlEscapeInt(0)};
+         dct:created ${sparqlEscapeDateTime(created)};
+         dct:modified ${sparqlEscapeDateTime(created)};
+         dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
+         dct:type ${sparqlEscapeString(type)};
+         ${userUri ? `nuao:involves ${sparqlEscapeUri(userUri)};` : ''}
+         nuao:involves ${sparqlEscapeUri(meeting.uri)};
+         ext:blockedBy ?blocking.
+    } WHERE {
+      OPTIONAL {
+        ?blocking a task:Task;
+          adms:status ${sparqlEscapeUri(TASK_STATUS_RUNNING)};
+          dct:modified ?blockModified;
+          dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
+          dct:type ${sparqlEscapeString(type)};
+          nuao:involves ${sparqlEscapeUri(meeting.uri)}.
+        FILTER (?blockModified > ${sparqlEscapeDateTime(DateTime.now().minus({ minutes: 10 }).toJSDate())})
+      }
+      BIND(IF(BOUND(?blocking), ${sparqlEscapeUri(TASK_STATUS_CREATED)}, ${sparqlEscapeUri(TASK_STATUS_RUNNING)}) AS ?status)
     }
   `;
     await update(queryString);
-    return new Task({
-      id,
-      type,
-      involves: meeting.uri,
-      created,
-      modified: created,
-      status: TASK_STATUS_CREATED,
-      uri,
-    });
+
+    return this.find(id);
   }
 
   /**
@@ -230,37 +245,47 @@ export default class Task {
     this.error = error ?? null;
   }
 
-  async updateStatus(status, reason) {
+  /**
+   * Internal - actually update status
+   * @param {string} status - the status to set
+   * @param {string} [reason] - an error reason to set as a message
+   * @returns {Promise<Task>}
+   */
+  async _setStatus(status, reason) {
     let taskError = null;
     if (reason) {
       taskError = new TaskError({ message: reason });
     }
     //prettier-ignore
     const queryString = `
-     ${prefixMap["mu"].toSparqlString()}
-     ${prefixMap["task"].toSparqlString()}
-     ${prefixMap["adms"].toSparqlString()}
-     ${prefixMap["oslc"].toSparqlString()}
+     ${prefixMap['mu'].toSparqlString()}
+     ${prefixMap['task'].toSparqlString()}
+     ${prefixMap['adms'].toSparqlString()}
+     ${prefixMap['oslc'].toSparqlString()}
+     ${prefixMap['dct'].toSparqlString()}
 
      DELETE {
        ?uri adms:status ?status.
+       ?uri dct:modified ?modified.
        ?uri task:error ?error.
        ?error ?errorP ?errorV.
      }
      INSERT {
-       ?uri adms:status ${sparqlEscapeUri(status)}.
+       ?uri adms:status ${sparqlEscapeUri(status)};
+            dct:modified ${sparqlEscapeDateTime(Date.now())}.
        ${
          taskError
            ? `?uri task:error ${sparqlEscapeUri(taskError.uri)}.
-	      ${sparqlEscapeUri(taskError.uri)} a oslc:Error.
-	      ${sparqlEscapeUri(taskError.uri)} mu:uuid ${sparqlEscapeString(taskError.id)}. 
-	      ${sparqlEscapeUri(taskError.uri)} oslc:message ${sparqlEscapeString(taskError.message)}.`
+              ${sparqlEscapeUri(taskError.uri)} a oslc:Error.
+              ${!taskError.id ? '' : `${sparqlEscapeUri(taskError.uri)} mu:uuid ${sparqlEscapeString(taskError.id)}.`} 
+              ${sparqlEscapeUri(taskError.uri)} oslc:message ${sparqlEscapeString(taskError.message)}.`
            : ''
        }
      }
      WHERE {
        ?uri a task:Task;
             mu:uuid ${sparqlEscapeString(this.id)};
+            dct:modified ?modified;
             adms:status ?status.
        OPTIONAL {
          ?uri task:error ?error.
@@ -269,7 +294,80 @@ export default class Task {
     }`;
     await update(queryString);
     this.status = status;
-
     this.error = taskError;
+
+    return this;
+  }
+
+  /**
+   * Update the task status if necessary
+   * @param {string} status - the status to set
+   * @param {string} [reason] - an error reason to set as a message
+   * @returns {Promise<Task>} - a task with the updated status. This could be a new object or could
+   * be the same one, so modifications should not be made to the object.
+   */
+  async updateStatus(status, reason) {
+    if (status === this.status) {
+      return this;
+    }
+    if (status !== TASK_STATUS_RUNNING) {
+      return this._setStatus(status, reason);
+    }
+    return this._tryToStart();
+  }
+
+  /**
+   * Internal -
+   * @returns {Promise<Task>}
+   */
+  async _tryToStart() {
+    //FIXME blockedBy
+    //prettier-ignore
+    const queryString = `
+     ${prefixMap["mu"].toSparqlString()}
+     ${prefixMap["task"].toSparqlString()}
+     ${prefixMap["adms"].toSparqlString()}
+     ${prefixMap["dct"].toSparqlString()}
+     ${prefixMap["nuao"].toSparqlString()}
+     ${prefixMap["xsd"].toSparqlString()}
+
+     DELETE {
+       ?uri adms:status ?oldStatus.
+       ?uri dct:modified ?modified.
+       ?uri task:error ?error.
+       ?error ?errorP ?errorV.
+     }
+     INSERT {
+       ?uri adms:status ?status;
+            dct:modified ${sparqlEscapeDateTime(Date.now())}.
+     }
+     WHERE {
+       ?uri a task:Task;
+            mu:uuid ${sparqlEscapeString(this.id)};
+            dct:modified ?modified;
+            adms:status ?oldStatus.
+      OPTIONAL {
+        ?blocking a task:Task;
+          adms:status ${sparqlEscapeUri(TASK_STATUS_RUNNING)};
+          dct:modified ?blockModified;
+          dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
+          dct:type ${sparqlEscapeString(this.type)};
+          nuao:involves ${sparqlEscapeUri(this.involves)}.
+        FILTER (?blocking != ?uri && ?blockModified > ${sparqlEscapeDateTime(DateTime.now().minus({ minutes: 10 }).toJSDate())})
+      }
+
+      BIND(IF(
+        BOUND(?blocking),
+        ?oldStatus,
+        ${sparqlEscapeUri(TASK_STATUS_RUNNING)}
+      ) AS ?status)
+       OPTIONAL {
+         ?uri task:error ?error.
+         ?error ?errorP ?errorV.
+       }
+    }`;
+    await update(queryString);
+
+    return Task.find(this.id);
   }
 }

--- a/models/task.js
+++ b/models/task.js
@@ -256,7 +256,6 @@ export default class Task {
     if (reason) {
       taskError = new TaskError({ message: reason });
     }
-    //prettier-ignore
     const queryString = `
      ${prefixMap['mu'].toSparqlString()}
      ${prefixMap['task'].toSparqlString()}
@@ -322,14 +321,13 @@ export default class Task {
    */
   async _tryToStart() {
     //FIXME blockedBy
-    //prettier-ignore
     const queryString = `
-     ${prefixMap["mu"].toSparqlString()}
-     ${prefixMap["task"].toSparqlString()}
-     ${prefixMap["adms"].toSparqlString()}
-     ${prefixMap["dct"].toSparqlString()}
-     ${prefixMap["nuao"].toSparqlString()}
-     ${prefixMap["xsd"].toSparqlString()}
+     ${prefixMap['mu'].toSparqlString()}
+     ${prefixMap['task'].toSparqlString()}
+     ${prefixMap['adms'].toSparqlString()}
+     ${prefixMap['dct'].toSparqlString()}
+     ${prefixMap['nuao'].toSparqlString()}
+     ${prefixMap['xsd'].toSparqlString()}
 
      DELETE {
        ?uri adms:status ?oldStatus.

--- a/models/task.js
+++ b/models/task.js
@@ -316,7 +316,8 @@ export default class Task {
   }
 
   /**
-   * Internal -
+   * Internal - try to set status to running, but does not do so if another running task already
+   * exists.
    * @returns {Promise<Task>}
    */
   async _tryToStart() {
@@ -366,6 +367,12 @@ export default class Task {
     }`;
     await update(queryString);
 
-    return Task.find(this.id);
+    // TODO add retry logic instead of just failing
+    const updated = await Task.find(this.id);
+    if (updated.status !== TASK_STATUS_RUNNING) {
+      console.error('Task blocked');
+      throw new Error('Task blocked');
+    }
+    return updated;
   }
 }

--- a/models/versioned-notulen.js
+++ b/models/versioned-notulen.js
@@ -60,7 +60,6 @@ export default class VersionedNotulen {
 
   /**
    * @typedef {Object} Params
-   * @property {string} [notulenUri]
    * @property {string} kind
    * @property {Meeting} meeting
    * @property {string} html
@@ -71,15 +70,10 @@ export default class VersionedNotulen {
    * @param {Params} args
    * @returns {Promise<VersionedNotulen>}
    */
-  static async create({ notulenUri, kind, meeting, html, publicTreatments }) {
-    let versionedNotulenUuid;
-    let versionedNotulenUri;
-    if (!notulenUri) {
-      versionedNotulenUuid = uuid();
-      versionedNotulenUri = `http://data.lblod.info/versioned-notulen/${versionedNotulenUuid}`;
-    } else {
-      versionedNotulenUri = notulenUri;
-    }
+  static async create({ kind, meeting, html, publicTreatments }) {
+    const versionedNotulenUuid = uuid();
+    const versionedNotulenUri = `http://data.lblod.info/versioned-notulen/${versionedNotulenUuid}`;
+    console.warn('creating Vnotulen', versionedNotulenUri, meeting.uri);
     // defend against existing resource
     // an ask query is extremely fast
     // specifically not taking Tombstones into account here, this a create
@@ -104,7 +98,6 @@ export default class VersionedNotulen {
     await update(`
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-      PREFIX pav: <http://purl.org/pav/>
       PREFIX prov: <http://www.w3.org/ns/prov#>
 
       INSERT DATA{

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@eslint/js": "^9.16.0",
         "@release-it-plugins/lerna-changelog": "^5.0.0",
         "@types/express": "^4.17.21",
+        "@types/luxon": "^3.7.1",
         "@types/mocha": "^10.0.10",
         "@types/node": "^20.11.0",
         "eslint": "^9.16.0",
@@ -5212,6 +5213,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@eslint/js": "^9.16.0",
     "@release-it-plugins/lerna-changelog": "^5.0.0",
     "@types/express": "^4.17.21",
+    "@types/luxon": "^3.7.1",
     "@types/mocha": "^10.0.10",
     "@types/node": "^20.11.0",
     "eslint": "^9.16.0",

--- a/routes/signing.js
+++ b/routes/signing.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // @ts-strict-ignore
 
 import express from 'express';
@@ -45,6 +44,7 @@ import { getUri } from '../support/resource-utils.js';
 
 import { parseBody } from '../support/parse-body.js';
 import VersionedExtract from '../models/versioned-behandeling.js';
+/** @import Task from '../models/task' */
 
 const router = express.Router();
 
@@ -73,7 +73,7 @@ router.post(
       );
       return res.send({ success: true }).end();
     } catch (err) {
-      console.log(err);
+      console.error('Error signing agenda', err);
       const error = new Error(
         `An error occurred while signing the agenda ${req.params.meetingUuid}: ${err}`
       );
@@ -89,6 +89,7 @@ router.post(
 router.post(
   '/signing/besluitenlijst/sign/:zittingIdentifier',
   async function (req, res, next) {
+    /** @type {Task} */
     let signingTask;
     try {
       const meetingUuid = req.params.zittingIdentifier;
@@ -101,7 +102,7 @@ router.post(
         userUri
       );
     } catch (err) {
-      console.log(err);
+      console.error('Error signing decision list', err);
       const error = new Error(
         `An error occurred while signing the besluitenlijst ${req.params.zittingIdentifier}: ${err}`
       );
@@ -176,7 +177,7 @@ router.post(
         return res.send({ success: true }).end();
       }
     } catch (err) {
-      console.log(err);
+      console.error('Error signing behandeling', err);
       const error = new Error(
         `An error occurred while signing the behandeling ${req.params.behandelingUuid}: ${err}`
       );
@@ -192,6 +193,7 @@ router.post(
 router.post('/signed-resources', async function (req, res, next) {
   try {
     const { relationships } = parseBody(req.body);
+    // @ts-ignore we could move to zod to get nice types here
     const versionedTreatmentUuid = relationships?.['versioned-behandeling']?.id;
     if (versionedTreatmentUuid) {
       const versionedTreatment = await VersionedExtract.find(
@@ -221,9 +223,9 @@ router.post('/signed-resources', async function (req, res, next) {
       }
     }
   } catch (err) {
-    console.log(err);
+    console.error('Error while creating signed resource', err);
     const error = new Error(
-      `An error occurred while signing the behandeling ${req.params.behandelingUuid}: ${err}`
+      `An error occurred while signing the resource: ${err}`
     );
     return next(error);
   }
@@ -236,6 +238,7 @@ router.post('/signed-resources', async function (req, res, next) {
 router.post(
   '/signing/notulen/sign/:zittingIdentifier',
   async function (req, res, next) {
+    /** @type {Task | undefined} */
     let signingTask;
     try {
       const meetingUuid = req.params.zittingIdentifier;
@@ -248,8 +251,8 @@ router.post(
         userUri
       );
     } catch (err) {
-      console.log(err);
-      await signingTask.updateStatus(TASK_STATUS_FAILURE, err.message);
+      console.error('Error attempting to create signing task', err);
+      await signingTask?.updateStatus(TASK_STATUS_FAILURE, err.message);
       const error = new Error(
         `An error occurred while signing the meeting notes ${req.params.zittingIdentifier}: ${err}`
       );
@@ -285,6 +288,7 @@ router.post(
 
       await signingTask.updateStatus(TASK_STATUS_SUCCESS);
     } catch (err) {
+      console.error('Error signing notulen', err);
       await signingTask.updateStatus(TASK_STATUS_FAILURE, err.message);
     }
   }

--- a/routes/signing.js
+++ b/routes/signing.js
@@ -260,7 +260,7 @@ router.post(
     }
 
     try {
-      await signingTask.updateStatus(TASK_STATUS_RUNNING);
+      signingTask = await signingTask.updateStatus(TASK_STATUS_RUNNING);
       const meetingUuid = req.params.zittingIdentifier;
       const meeting = await Meeting.find(meetingUuid);
       const treatments = await Treatment.findAll({ meetingUuid });

--- a/routes/task.js
+++ b/routes/task.js
@@ -6,29 +6,25 @@ const router = express.Router();
 router.get('/publication-tasks/:id', async function (req, res) {
   const taskUuid = req.params.id;
   const task = await Task.find(taskUuid);
-  if (task) {
-    res.status(200).send({
-      data: {
-        id: task.id,
-        uri: task.uri,
-        status: task.status,
-        type: task.type,
-        created: task.created,
-        modified: task.modified,
-        involves: task.involves,
-        taskType: task.type,
-        error: task.error
-          ? {
-              id: task.error.id,
-              message: task.error.message,
-              uri: task.error.uri,
-            }
-          : undefined,
-      },
-    });
-  } else {
-    res.status(404).send(`task with id ${taskUuid} was not found`);
-  }
+  res.status(200).send({
+    data: {
+      id: task.id,
+      uri: task.uri,
+      status: task.status,
+      type: task.type,
+      created: task.created,
+      modified: task.modified,
+      involves: task.involves,
+      taskType: task.type,
+      error: task.error
+        ? {
+            id: task.error.id,
+            message: task.error.message,
+            uri: task.error.uri,
+          }
+        : undefined,
+    },
+  });
 });
 
 export default router;

--- a/support/notulen-utils.js
+++ b/support/notulen-utils.js
@@ -116,12 +116,10 @@ export async function ensureVersionedNotulen(
   publicTreatments = []
 ) {
   let versionedNotulen = await VersionedNotulen.query({ meeting, kind });
-  let notulenUri;
   if (versionedNotulen) {
     console.log(
       `Reusing versioned notulen ${versionedNotulen.uri} of kind ${kind}`
     );
-    notulenUri = versionedNotulen.uri;
     if (versionedNotulen.html) {
       return versionedNotulen.uri;
     } else {
@@ -153,7 +151,6 @@ export async function ensureVersionedNotulen(
     html = constructHtmlForMeetingNotesFromData(data);
   }
   versionedNotulen = await VersionedNotulen.create({
-    notulenUri,
     meeting,
     html,
     kind,

--- a/support/pre-importer.js
+++ b/support/pre-importer.js
@@ -49,8 +49,8 @@ async function getVersionedContent(uri, contentPredicate) {
         ${prefixMap['ext'].toSparqlString()}
         SELECT ?content ?physicalFileUri
         WHERE {
-         OPTIONAL { ${sparqlEscapeUri(uri)} ${contentPredicate} ?content. }
-         OPTIONAL { ${sparqlEscapeUri(
+         { ${sparqlEscapeUri(uri)} ${contentPredicate} ?content. }
+         UNION { ${sparqlEscapeUri(
            uri
          )} prov:generated/^nie:dataSource ?physicalFileUri. }
         }`;

--- a/support/prefixes.js
+++ b/support/prefixes.js
@@ -79,6 +79,7 @@ const prefixMap = {
   oslc: new Prefix("oslc", "http://open-services.net/ns/core#"),
   task: new Prefix("task", "http://redpencil.data.gift/vocabularies/tasks/"),
   nuao: new Prefix("nuao", "http://www.semanticdesktop.org/ontologies/2010/01/25/nuao#"),
+  xsd: new Prefix("xsd", "http://www.w3.org/2001/XMLSchema#"),
 };
 
 export { prefixes, prefixMap };

--- a/support/task-utils.js
+++ b/support/task-utils.js
@@ -1,7 +1,6 @@
-// @ts-strict-ignore
-
 /** @import { Response } from 'express' */
 import Task from '../models/task.js';
+import AppError from './error-utils.js';
 /** @import Meeting from '../models/meeting' */
 
 /**
@@ -10,11 +9,13 @@ import Task from '../models/task.js';
  * @param {string} [userUri]
  * */
 export async function ensureTask(meeting, taskType, userUri) {
-  let task = userUri
-    ? await Task.query({ meetingUri: meeting.uri, type: taskType, userUri })
-    : await Task.query({ meetingUri: meeting.uri, type: taskType });
+  /** @type {Task | null} */
+  let task = null;
   if (!task) {
     task = await Task.create(meeting, taskType, userUri);
+  }
+  if (!task) {
+    throw new AppError(500, 'Unable to create task');
   }
   return task;
 }

--- a/support/types.d.ts
+++ b/support/types.d.ts
@@ -15,6 +15,7 @@ declare module 'mu' {
     ? {
         head: {
           vars: string[];
+          link: [];
         };
         results: {
           bindings: BindingObject<ObjOrIsAsk>[];
@@ -32,8 +33,14 @@ declare module 'mu' {
    * objects. If this is an ASK query, pass `true` instead as the return of this query will be
    * different.
    */
+  export interface UserOptions {
+    sudo?: boolean;
+    scope?: string;
+    endpoint?: string;
+  }
   export const query: <ObjOrIsAsk extends ObjectToBind | true = ObjectToBind>(
-    query: string
+    query: string,
+    opts?: UserOptions,
   ) => Promise<SparqlResponse<ObjOrIsAsk>>;
   export const update: (query: string) => Promise<void>;
   export const uuid: () => string;
@@ -43,7 +50,7 @@ declare module 'mu' {
   export const sparqlEscapeInt: (value: number) => string;
   export const sparqlEscapeDecimal: (value: number) => string;
   export const sparqlEscapeFloat: (value: number) => string;
-  export const sparqlEscapeDateTime: (value: Date) => string;
+  export const sparqlEscapeDateTime: (value: Date | string | number) => string;
   export const sparqlEscapeBool: (value: boolean) => string;
   export const sparqlEscapeDate: (value: Date) => string;
   export const errorHandler: RequestHandler;
@@ -74,6 +81,7 @@ declare module 'mu' {
     errorHandler: typeof errorHandler;
     sparql: typeof sparql;
     SPARQL: typeof SPARQL;
+    newSparqlClient: typeof newSparqlClient;
   };
   export default mu;
 }


### PR DESCRIPTION
I've split this in 2 as the ticket can actually be completed by this part, since it disallows concurrent tasks of the same type for the same meeting. I will create a separate PR with retry logic. This is done so that the review is smaller, and we can just go with this if we think retrying might be problematic.

When creating tasks, they are now created in either the 'created' or 'running' state, depending on whether an existing task for that meeting and type exists. When trying to set the status to 'running' to continue the task, this fails if there is another concurrent task. Both of these are done in atomic updates to the triplestore, so while they have 2 steps (update-then-select), the result of the update is different if it succeeds or fails, so there's no race condition on the result of the select.

I added types as I went, and discovered a few issues that have been there since the beginning...

Testing is hard without either adding delays or breakpoints, but in general, we should re-test all signing and publishing behaviour, ideally with 2 clients (e.g. the reader and writer roles) hitting endpoints near-simultaneously. If adding timeouts, make sure to add them after the initial task creation has returned, as otherwise it does not match how this would appear in a really slow system.

Jira ticket: https://binnenland.atlassian.net/browse/GN-6092