### PR TITLE
Retry blocked tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Once a specific document is generated for signing or publication the content is 
 ## configuration
 The following environment variables can be set to configure the service:
 
+  -  *TASK_RETRY_DELAY_MS*: The delay between retries of tasks in case they are blocked by a concurrent task. Default: `2000`
+  -  *TASK_RETRY_LIMIT*: The limit of number of retries of tasks in case they are blocked by a concurrent task. Default: `20`
+  -  *TASK_LOCK_EXPIRY_MINS*: The running time allowed for a task before it is considered 'stale' and is no longer considered as blocking for future tasks. Default: `5`
   -  *DATE_FORMAT*: datetime format passed to luxon, see the [table of tokens](https://moment.github.io/luxon/docs/manual/formatting.html#table-of-tokens) for more information. Default: `dd/MM/yyyy HH:mm:ss`
 
 ## model

--- a/models/task.js
+++ b/models/task.js
@@ -50,6 +50,11 @@ export class TaskError {
   }
 }
 
+// TODO These should be config options
+const TASK_RETRY_DELAY_MS = 500;
+const TASK_RETRY_LIMIT = 10;
+const TASK_LOCK_EXPIRY_MINS = 10;
+
 export default class Task {
   /**
    * Creates a new task. If a running task of the same type for the same meeting already exists, it
@@ -321,57 +326,78 @@ export default class Task {
    * @returns {Promise<Task>}
    */
   async _tryToStart() {
-    //FIXME blockedBy
-    const queryString = `
-     ${prefixMap['mu'].toSparqlString()}
-     ${prefixMap['task'].toSparqlString()}
-     ${prefixMap['adms'].toSparqlString()}
-     ${prefixMap['dct'].toSparqlString()}
-     ${prefixMap['nuao'].toSparqlString()}
-     ${prefixMap['xsd'].toSparqlString()}
-
-     DELETE {
-       ?uri adms:status ?oldStatus.
-       ?uri dct:modified ?modified.
-       ?uri task:error ?error.
-       ?error ?errorP ?errorV.
-     }
-     INSERT {
-       ?uri adms:status ?status;
-            dct:modified ${sparqlEscapeDateTime(Date.now())}.
-     }
-     WHERE {
-       ?uri a task:Task;
-            mu:uuid ${sparqlEscapeString(this.id)};
-            dct:modified ?modified;
-            adms:status ?oldStatus.
-      OPTIONAL {
-        ?blocking a task:Task;
-          adms:status ${sparqlEscapeUri(TASK_STATUS_RUNNING)};
-          dct:modified ?blockModified;
-          dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
-          dct:type ${sparqlEscapeString(this.type)};
-          nuao:involves ${sparqlEscapeUri(this.involves)}.
-        FILTER (?blocking != ?uri && ?blockModified > ${sparqlEscapeDateTime(DateTime.now().minus({ minutes: 10 }).toJSDate())})
+    /** @type {Task | undefined} */
+    let updated;
+    // TODO this should start at the queried value but we don't currently have it
+    let retryCount = 0;
+    do {
+      if (updated) {
+        // updated is defined after the first loop, so wait before retrying
+        await new Promise((res) => setTimeout(res, TASK_RETRY_DELAY_MS));
+        retryCount++;
       }
+      //FIXME blockedBy
+      const queryString = `
+       ${prefixMap['mu'].toSparqlString()}
+       ${prefixMap['task'].toSparqlString()}
+       ${prefixMap['adms'].toSparqlString()}
+       ${prefixMap['dct'].toSparqlString()}
+       ${prefixMap['nuao'].toSparqlString()}
+       ${prefixMap['xsd'].toSparqlString()}
 
-      BIND(IF(
-        BOUND(?blocking),
-        ?oldStatus,
-        ${sparqlEscapeUri(TASK_STATUS_RUNNING)}
-      ) AS ?status)
-       OPTIONAL {
+       DELETE {
+         ?uri adms:status ?oldStatus.
+         ?uri dct:modified ?modified.
+         ?uri task:numberOfRetries ?retries.
          ?uri task:error ?error.
          ?error ?errorP ?errorV.
        }
-    }`;
-    await update(queryString);
+       INSERT {
+         ?uri adms:status ?status;
+              task:numberOfRetries ${sparqlEscapeInt(retryCount)};
+              dct:modified ${sparqlEscapeDateTime(Date.now())}.
+       }
+       WHERE {
+         ?uri a task:Task;
+              mu:uuid ${sparqlEscapeString(this.id)};
+              dct:modified ?modified;
+              task:numberOfRetries ?retries;
+              adms:status ?oldStatus.
+        OPTIONAL {
+          ?blocking a task:Task;
+                    adms:status ${sparqlEscapeUri(TASK_STATUS_RUNNING)};
+                    dct:modified ?blockModified;
+                    dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
+                    dct:type ${sparqlEscapeString(this.type)};
+                    nuao:involves ${sparqlEscapeUri(this.involves)}.
+          FILTER (?blocking != ?uri && ?blockModified > ${sparqlEscapeDateTime(DateTime.now().minus({ minutes: TASK_LOCK_EXPIRY_MINS }).toJSDate())})
+        }
 
-    // TODO add retry logic instead of just failing
-    const updated = await Task.find(this.id);
+        BIND(IF(
+          BOUND(?blocking),
+          ?oldStatus,
+          ${sparqlEscapeUri(TASK_STATUS_RUNNING)}
+        ) AS ?status)
+         OPTIONAL {
+           ?uri task:error ?error.
+           ?error ?errorP ?errorV.
+         }
+      }`;
+      await update(queryString);
+
+      updated = await Task.find(this.id);
+    } while (
+      updated.status !== TASK_STATUS_RUNNING &&
+      retryCount < TASK_RETRY_LIMIT
+    );
+
     if (updated.status !== TASK_STATUS_RUNNING) {
-      console.error('Task blocked');
-      throw new Error('Task blocked');
+      const err = new AppError(
+        503,
+        `Unable to unlock task after ${retryCount} retries. Task: ${this.uri}`
+      );
+      console.error(err);
+      throw err;
     }
     return updated;
   }

--- a/models/task.js
+++ b/models/task.js
@@ -124,13 +124,14 @@ export default class Task {
      ${prefixMap['adms'].toSparqlString()}
      ${prefixMap['oslc'].toSparqlString()}
      ${prefixMap['besluit'].toSparqlString()}
-     SELECT ?uri ?uuid ?type ?involves ?status ?modified ?created ?error ?errorId ?errorMessage WHERE {
+     SELECT ?uri ?uuid ?type ?involves ?status ?modified ?retries ?created ?error ?errorId ?errorMessage WHERE {
        BIND(${sparqlEscapeString(uuid)} AS ?uuid)
        ?uri a task:Task;
             mu:uuid ?uuid;
             dct:type ?type;
             dct:created ?created;
             dct:modified ?modified;
+            task:numberOfRetries ?retries;
             nuao:involves ?involves;
             dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
             adms:status ?status.
@@ -166,12 +167,13 @@ export default class Task {
      ${prefixMap['dct'].toSparqlString()}
      ${prefixMap['adms'].toSparqlString()}
      ${prefixMap['oslc'].toSparqlString()}
-     SELECT ?uri ?uuid ?status ?modified ?created ?error ?errorId ?errorMessage WHERE {
+     SELECT ?uri ?uuid ?status ?modified ?created ?retries ?error ?errorId ?errorMessage WHERE {
        ?uri a task:Task;
             mu:uuid ?uuid;
             dct:type ${sparqlEscapeString(type)};
             dct:created ?created;
             dct:modified ?modified;
+            task:numberOfRetries ?retries;
             nuao:involves ${sparqlEscapeUri(meetingUri)};
             dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
             adms:status ?status.
@@ -213,6 +215,7 @@ export default class Task {
       created: binding.created.value,
       modified: binding.modified.value,
       status: binding.status.value,
+      retries: Number.parseInt(binding.retries.value, 10),
       involves: binding.involves.value,
       type: binding.type.value,
       error: taskError,
@@ -228,10 +231,21 @@ export default class Task {
    * @property {string} modified
    * @property {string} status
    * @property {string} uri
+   * @property {number} [retries]
    * @property {TaskError} [error]
    */
   /** @param {TaskArgs} taskArgs */
-  constructor({ id, uri, created, status, modified, type, involves, error }) {
+  constructor({
+    id,
+    uri,
+    created,
+    status,
+    modified,
+    type,
+    involves,
+    retries = 0,
+    error,
+  }) {
     /** @type {string} */
     this.id = id;
     /** @type {string} */
@@ -246,6 +260,8 @@ export default class Task {
     this.status = status;
     /** @type {string} */
     this.uri = uri;
+    /** @type {number} */
+    this.retries = retries;
     /** @type {TaskError | null} */
     this.error = error ?? null;
   }
@@ -328,8 +344,7 @@ export default class Task {
   async _tryToStart() {
     /** @type {Task | undefined} */
     let updated;
-    // TODO this should start at the queried value but we don't currently have it
-    let retryCount = 0;
+    let retryCount = this.retries;
     do {
       if (updated) {
         // updated is defined after the first loop, so wait before retrying

--- a/models/task.js
+++ b/models/task.js
@@ -320,7 +320,9 @@ export default class Task {
   }
 
   /**
-   * Update the task status if necessary
+   * Update the task status if necessary. If the status matches, this is a no-op.
+   * Setting the task to RUNNING triggers block detection, which only returns once the task can
+   * proceed, or fails if it cannot after limited retries.
    * @param {string} status - the status to set
    * @param {string} [reason] - an error reason to set as a message
    * @returns {Promise<Task>} - a task with the updated status. This could be a new object or could
@@ -338,7 +340,7 @@ export default class Task {
 
   /**
    * Internal - try to set status to running, but does not do so if another running task already
-   * exists.
+   * exists. Retries a configurable number of times before failing.
    * @returns {Promise<Task>}
    */
   async _tryToStart() {
@@ -351,7 +353,6 @@ export default class Task {
         await new Promise((res) => setTimeout(res, TASK_RETRY_DELAY_MS));
         retryCount++;
       }
-      //FIXME blockedBy
       const queryString = `
        ${prefixMap['mu'].toSparqlString()}
        ${prefixMap['task'].toSparqlString()}
@@ -359,17 +360,20 @@ export default class Task {
        ${prefixMap['dct'].toSparqlString()}
        ${prefixMap['nuao'].toSparqlString()}
        ${prefixMap['xsd'].toSparqlString()}
+       ${prefixMap['ext'].toSparqlString()}
 
        DELETE {
          ?uri adms:status ?oldStatus.
          ?uri dct:modified ?modified.
          ?uri task:numberOfRetries ?retries.
+         ?uri ext:blockedBy ?oldBlocking.
          ?uri task:error ?error.
          ?error ?errorP ?errorV.
        }
        INSERT {
          ?uri adms:status ?status;
               task:numberOfRetries ${sparqlEscapeInt(retryCount)};
+              ext:blockedBy ?blocking;
               dct:modified ${sparqlEscapeDateTime(Date.now())}.
        }
        WHERE {
@@ -378,21 +382,19 @@ export default class Task {
               dct:modified ?modified;
               task:numberOfRetries ?retries;
               adms:status ?oldStatus.
-        OPTIONAL {
-          ?blocking a task:Task;
-                    adms:status ${sparqlEscapeUri(TASK_STATUS_RUNNING)};
-                    dct:modified ?blockModified;
-                    dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
-                    dct:type ${sparqlEscapeString(this.type)};
-                    nuao:involves ${sparqlEscapeUri(this.involves)}.
-          FILTER (?blocking != ?uri && ?blockModified > ${sparqlEscapeDateTime(DateTime.now().minus({ minutes: TASK_LOCK_EXPIRY_MINS }).toJSDate())})
-        }
-
-        BIND(IF(
-          BOUND(?blocking),
-          ?oldStatus,
-          ${sparqlEscapeUri(TASK_STATUS_RUNNING)}
-        ) AS ?status)
+         OPTIONAL {
+           ?uri ext:blockedBy ?oldBlocking.
+         }
+         OPTIONAL {
+           ?blocking a task:Task;
+                     adms:status ${sparqlEscapeUri(TASK_STATUS_RUNNING)};
+                     dct:modified ?blockModified;
+                     dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
+                     dct:type ${sparqlEscapeString(this.type)};
+                     nuao:involves ${sparqlEscapeUri(this.involves)}.
+           FILTER (?blocking != ?uri && ?blockModified > ${sparqlEscapeDateTime(DateTime.now().minus({ minutes: TASK_LOCK_EXPIRY_MINS }).toJSDate())})
+         }
+         BIND(IF(BOUND(?blocking), ?oldStatus, ${sparqlEscapeUri(TASK_STATUS_RUNNING)}) AS ?status)
          OPTIONAL {
            ?uri task:error ?error.
            ?error ?errorP ?errorV.

--- a/models/task.js
+++ b/models/task.js
@@ -50,10 +50,15 @@ export class TaskError {
   }
 }
 
-// TODO These should be config options
-const TASK_RETRY_DELAY_MS = 500;
-const TASK_RETRY_LIMIT = 10;
-const TASK_LOCK_EXPIRY_MINS = 10;
+const TASK_RETRY_DELAY_MS = process.env.TASK_RETRY_DELAY_MS
+  ? Number.parseInt(process.env.TASK_RETRY_DELAY_MS, 10)
+  : 2000;
+const TASK_RETRY_LIMIT = process.env.TASK_RETRY_LIMIT
+  ? Number.parseInt(process.env.TASK_RETRY_LIMIT, 10)
+  : 20;
+const TASK_LOCK_EXPIRY_MINS = process.env.TASK_LOCK_EXPIRY_MINS
+  ? Number.parseInt(process.env.TASK_LOCK_EXPIRY_MINS, 10)
+  : 5;
 
 export default class Task {
   /**

--- a/routes/preview.js
+++ b/routes/preview.js
@@ -275,8 +275,10 @@ router.post(
           (publicTreatment) => publicTreatment.id
         ) || [];
 
-      const meeting = await Meeting.find(meetingUuid);
-      const treatments = await Treatment.findAll({ meetingUuid });
+      const [meeting, treatments] = await Promise.all([
+        Meeting.find(meetingUuid),
+        Treatment.findAll({ meetingUuid }),
+      ]);
       const publicationHtml = await generateNotulenPreview(
         meeting,
         treatments,

--- a/routes/publication.js
+++ b/routes/publication.js
@@ -129,8 +129,10 @@ router.post(
   '/signing/behandeling/publish/:zittingIdentifier/:behandelingUuid',
   async function (req, res, next) {
     try {
-      const meeting = await Meeting.find(req.params.zittingIdentifier);
-      const treatment = await Treatment.find(req.params.behandelingUuid);
+      const [meeting, treatment] = await Promise.all([
+        Meeting.find(req.params.zittingIdentifier),
+        Treatment.find(req.params.behandelingUuid),
+      ]);
       const meetingErrors = validateMeeting(meeting);
       const treatmentErrors = await validateTreatment(treatment);
       const errors = [...meetingErrors, ...treatmentErrors];

--- a/routes/signing.js
+++ b/routes/signing.js
@@ -93,8 +93,10 @@ router.post(
     let signingTask;
     try {
       const meetingUuid = req.params.zittingIdentifier;
-      const meeting = await Meeting.find(meetingUuid);
-      const userUri = await fetchCurrentUser(req.header('MU-SESSION-ID'));
+      const [meeting, userUri] = await Promise.all([
+        Meeting.find(meetingUuid),
+        fetchCurrentUser(req.header('MU-SESSION-ID')),
+      ]);
       signingTask = await returnEnsuredTaskId(
         res,
         meeting,
@@ -134,8 +136,10 @@ router.post(
   '/signing/behandeling/sign/:zittingIdentifier/:behandelingUuid',
   async function (req, res, next) {
     try {
-      const meeting = await Meeting.find(req.params.zittingIdentifier);
-      const treatment = await Treatment.find(req.params.behandelingUuid);
+      const [meeting, treatment] = await Promise.all([
+        Meeting.find(req.params.zittingIdentifier),
+        Treatment.find(req.params.behandelingUuid),
+      ]);
       const meetingErrors = validateMeeting(meeting);
       const treatmentErrors = await validateTreatment(treatment);
       const errors = [...meetingErrors, ...treatmentErrors];
@@ -242,8 +246,10 @@ router.post(
     let signingTask;
     try {
       const meetingUuid = req.params.zittingIdentifier;
-      const meeting = await Meeting.find(meetingUuid);
-      const userUri = await fetchCurrentUser(req.header('MU-SESSION-ID'));
+      const [meeting, userUri] = await Promise.all([
+        Meeting.find(meetingUuid),
+        fetchCurrentUser(req.header('MU-SESSION-ID')),
+      ]);
       signingTask = await returnEnsuredTaskId(
         res,
         meeting,
@@ -262,8 +268,10 @@ router.post(
     try {
       signingTask = await signingTask.updateStatus(TASK_STATUS_RUNNING);
       const meetingUuid = req.params.zittingIdentifier;
-      const meeting = await Meeting.find(meetingUuid);
-      const treatments = await Treatment.findAll({ meetingUuid });
+      const [meeting, treatments] = await Promise.all([
+        Meeting.find(meetingUuid),
+        Treatment.findAll({ meetingUuid }),
+      ]);
       let errors = validateMeeting(meeting);
       const attachments = [];
       for (const treatment of treatments) {

--- a/routes/task.js
+++ b/routes/task.js
@@ -3,28 +3,32 @@ import Task from '../models/task.js';
 
 const router = express.Router();
 
-router.get('/publication-tasks/:id', async function (req, res) {
+router.get('/publication-tasks/:id', async function (req, res, next) {
   const taskUuid = req.params.id;
-  const task = await Task.find(taskUuid);
-  res.status(200).send({
-    data: {
-      id: task.id,
-      uri: task.uri,
-      status: task.status,
-      type: task.type,
-      created: task.created,
-      modified: task.modified,
-      involves: task.involves,
-      taskType: task.type,
-      error: task.error
-        ? {
-            id: task.error.id,
-            message: task.error.message,
-            uri: task.error.uri,
-          }
-        : undefined,
-    },
-  });
+  try {
+    const task = await Task.find(taskUuid);
+    res.status(200).send({
+      data: {
+        id: task.id,
+        uri: task.uri,
+        status: task.status,
+        type: task.type,
+        created: task.created,
+        modified: task.modified,
+        involves: task.involves,
+        taskType: task.type,
+        error: task.error
+          ? {
+              id: task.error.id,
+              message: task.error.message,
+              uri: task.error.uri,
+            }
+          : undefined,
+      },
+    });
+  } catch (err) {
+    return next(err);
+  }
 });
 
 export default router;

--- a/support/extract-utils.js
+++ b/support/extract-utils.js
@@ -65,8 +65,10 @@ async function buildExtractForTreatment(
 
 // here for legacy purposes
 export async function buildAllExtractsForMeeting(meetingUuid) {
-  const treatments = await Treatment.findAll({ meetingUuid });
-  const meeting = await Meeting.find(meetingUuid);
+  const [treatments, meeting] = await Promise.all([
+    Treatment.findAll({ meetingUuid }),
+    Meeting.find(meetingUuid),
+  ]);
   const participationList = await fetchParticipationList(meeting.uri);
   let participantCache;
   if (participationList) {


### PR DESCRIPTION
Adds automatic retries to [Task blocking](https://github.com/lblod/notulen-prepublish-service/pull/130). Testing is much the same except that in normal conditions tasks should always succeed, even when performing actions simultaneously.

There is no automatic resumption or cleanup of tasks, but stuck running tasks should no longer be considered 'running' for blocking purposes after a (configurable) 5 minute delay.