### PR TITLE
Use Tasks to prevent concurrent extract signing using existing endpoint

### DIFF
--- a/models/signed-resource.js
+++ b/models/signed-resource.js
@@ -5,6 +5,7 @@ import { query, sparqlEscapeUri } from 'mu';
 import { prefixMap } from '../support/prefixes.js';
 
 export default class SignedResource {
+  /** @param {string} uri */
   static async findURI(uri) {
     const queryString = `
     ${prefixMap['mu'].toSparqlString()}

--- a/models/task.js
+++ b/models/task.js
@@ -17,6 +17,8 @@ export const TASK_TYPE_SIGNING_DECISION_LIST = 'decisionListSignature';
 export const TASK_TYPE_PUBLISHING_DECISION_LIST = 'decisionListPublication';
 export const TASK_TYPE_SIGNING_MEETING_NOTES = 'meetingNotesSignature';
 export const TASK_TYPE_PUBLISHING_MEETING_NOTES = 'meetingNotesPublication';
+export const TASK_TYPE_SIGNING_VERSIONED_TREATMENT =
+  'versionedTreatmentSignature';
 export const TASK_STATUS_FAILURE =
   'http://lblod.data.gift/besluit-publicatie-melding-statuses/failure';
 export const TASK_STATUS_CREATED =

--- a/models/task.js
+++ b/models/task.js
@@ -131,7 +131,8 @@ export default class Task {
      ${prefixMap['adms'].toSparqlString()}
      ${prefixMap['oslc'].toSparqlString()}
      ${prefixMap['besluit'].toSparqlString()}
-     SELECT ?uri ?uuid ?type ?involves ?status ?modified ?retries ?created ?error ?errorId ?errorMessage WHERE {
+     ${prefixMap['ext'].toSparqlString()}
+     SELECT ?uri ?uuid ?type ?involves ?status ?modified ?retries ?created ?createdResource ?error ?errorId ?errorMessage WHERE {
        BIND(${sparqlEscapeString(uuid)} AS ?uuid)
        ?uri a task:Task;
             mu:uuid ?uuid;
@@ -143,6 +144,9 @@ export default class Task {
             dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
             adms:status ?status.
         ?involves a besluit:Zitting.
+       OPTIONAL {
+         ?uri ext:createdResource ?createdResource.
+       }
        OPTIONAL {
          ?uri task:error ?error.
          ?error mu:uuid ?errorId.
@@ -174,7 +178,8 @@ export default class Task {
      ${prefixMap['dct'].toSparqlString()}
      ${prefixMap['adms'].toSparqlString()}
      ${prefixMap['oslc'].toSparqlString()}
-     SELECT ?uri ?uuid ?status ?modified ?created ?retries ?error ?errorId ?errorMessage WHERE {
+     ${prefixMap['ext'].toSparqlString()}
+     SELECT ?uri ?uuid ?status ?modified ?created ?retries ?createdResource ?error ?errorId ?errorMessage WHERE {
        ?uri a task:Task;
             mu:uuid ?uuid;
             dct:type ${sparqlEscapeString(type)};
@@ -185,6 +190,9 @@ export default class Task {
             dct:creator <http://lblod.data.gift/services/notulen-prepublish-service>;
             adms:status ?status.
 
+       OPTIONAL {
+         ?uri ext:createdResource ?createdResource.
+       }
        OPTIONAL {
          ?uri task:error ?error.
          ?error mu:uuid ?errorId.
@@ -224,6 +232,7 @@ export default class Task {
       status: binding.status.value,
       retries: Number.parseInt(binding.retries.value, 10),
       involves: binding.involves.value,
+      createdResource: binding.createdResource?.value,
       type: binding.type.value,
       error: taskError,
     });
@@ -238,6 +247,7 @@ export default class Task {
    * @property {string} modified
    * @property {string} status
    * @property {string} uri
+   * @property {string} [createdResource]
    * @property {number} [retries]
    * @property {TaskError} [error]
    */
@@ -250,6 +260,7 @@ export default class Task {
     modified,
     type,
     involves,
+    createdResource,
     retries = 0,
     error,
   }) {
@@ -267,6 +278,8 @@ export default class Task {
     this.status = status;
     /** @type {string} */
     this.uri = uri;
+    /** @type {string | undefined} */
+    this.createdResource = createdResource;
     /** @type {number} */
     this.retries = retries;
     /** @type {TaskError | null} */
@@ -277,9 +290,10 @@ export default class Task {
    * Internal - actually update status
    * @param {string} status - the status to set
    * @param {string} [reason] - an error reason to set as a message
+   * @param {string} [createdResource] - URI of the resource created, if successful
    * @returns {Promise<Task>}
    */
-  async _setStatus(status, reason) {
+  async _setStatus(status, reason, createdResource) {
     let taskError = null;
     if (reason) {
       taskError = new TaskError({ message: reason });
@@ -290,16 +304,19 @@ export default class Task {
      ${prefixMap['adms'].toSparqlString()}
      ${prefixMap['oslc'].toSparqlString()}
      ${prefixMap['dct'].toSparqlString()}
+     ${prefixMap['ext'].toSparqlString()}
 
      DELETE {
        ?uri adms:status ?status.
        ?uri dct:modified ?modified.
+       ?uri ext:createdResource ?createdResource.
        ?uri task:error ?error.
        ?error ?errorP ?errorV.
      }
      INSERT {
        ?uri adms:status ${sparqlEscapeUri(status)};
             dct:modified ${sparqlEscapeDateTime(Date.now())}.
+       ${createdResource ? `?uri ext:createdResource ${sparqlEscapeUri(createdResource)}.` : ''}
        ${
          taskError
            ? `?uri task:error ${sparqlEscapeUri(taskError.uri)}.
@@ -314,6 +331,9 @@ export default class Task {
             mu:uuid ${sparqlEscapeString(this.id)};
             dct:modified ?modified;
             adms:status ?status.
+       OPTIONAL {
+         ?uri ext:createdResource ?createdResource.
+       }
        OPTIONAL {
          ?uri task:error ?error.
          ?error ?errorP ?errorV.
@@ -332,15 +352,16 @@ export default class Task {
    * proceed, or fails if it cannot after limited retries.
    * @param {string} status - the status to set
    * @param {string} [reason] - an error reason to set as a message
+   * @param {string} [createdResource] - URI of the resource created, if successful
    * @returns {Promise<Task>} - a task with the updated status. This could be a new object or could
    * be the same one, so modifications should not be made to the object.
    */
-  async updateStatus(status, reason) {
+  async updateStatus(status, reason, createdResource) {
     if (status === this.status) {
       return this;
     }
     if (status !== TASK_STATUS_RUNNING) {
-      return this._setStatus(status, reason);
+      return this._setStatus(status, reason, createdResource);
     }
     return this._tryToStart();
   }

--- a/routes/signing.js
+++ b/routes/signing.js
@@ -191,6 +191,67 @@ router.post(
   }
 );
 
+router.post(
+  '/signing/uittreksel/sign/:versionedTreatmentId',
+  async function (req, res, next) {
+    /** @type {Treatment | undefined} */
+    let treatment;
+    /** @type {Meeting | undefined} */
+    let meeting;
+    /** @type {Task | undefined} */
+    let signingTask;
+    try {
+      if (req.params.versionedTreatmentId) {
+        const versionedTreatment = await VersionedExtract.find(
+          req.params.versionedTreatmentId
+        );
+        treatment = await Treatment.findUri(versionedTreatment.treatment);
+        meeting = await Meeting.findURI(treatment.meeting);
+        signingTask = await returnEnsuredTaskId(
+          res,
+          meeting,
+          TASK_TYPE_SIGNING_VERSIONED_TREATMENT
+        );
+      }
+    } catch (err) {
+      console.error('Error while creating signed resource task', err);
+      const error = new Error(
+        `An error occurred while signing the resource task: ${err}`
+      );
+      return next(error);
+    }
+    try {
+      if (treatment && meeting && signingTask) {
+        signingTask = await signingTask.updateStatus(TASK_STATUS_RUNNING);
+        const meetingErrors = validateMeeting(meeting);
+        const treatmentErrors = await validateTreatment(treatment);
+        const errors = [...meetingErrors, ...treatmentErrors];
+        if (errors.length) {
+          await signingTask.updateStatus(
+            TASK_STATUS_FAILURE,
+            errors.join('; ')
+          );
+        } else {
+          const versionedExtractUri = await ensureVersionedExtract(
+            treatment,
+            meeting
+          );
+
+          await signVersionedExtract(
+            versionedExtractUri,
+            req.header('MU-SESSION-ID'),
+            'getekend',
+            treatment.attachments
+          );
+          signingTask.updateStatus(TASK_STATUS_SUCCESS);
+        }
+      }
+    } catch (err) {
+      console.error('Error while signing extract', err);
+      await signingTask?.updateStatus(TASK_STATUS_FAILURE, err.message);
+    }
+  }
+);
 /**
  * Creates a signed resource for the provided resource (currently only a treatment is supported)
  * Ensures the prepublished behandeling that is signed is persisted in the store and attached to the document container

--- a/routes/signing.js
+++ b/routes/signing.js
@@ -4,13 +4,14 @@ import express from 'express';
 import Meeting from '../models/meeting.js';
 import Treatment from '../models/treatment.js';
 import SignedResource from '../models/signed-resource.js';
-import { returnEnsuredTaskId } from '../support/task-utils.js';
+import { ensureTask, returnEnsuredTaskId } from '../support/task-utils.js';
 import {
   TASK_STATUS_FAILURE,
   TASK_STATUS_RUNNING,
   TASK_STATUS_SUCCESS,
   TASK_TYPE_SIGNING_DECISION_LIST,
   TASK_TYPE_SIGNING_MEETING_NOTES,
+  TASK_TYPE_SIGNING_VERSIONED_TREATMENT,
 } from '../models/task.js';
 import validateMeeting from '../support/validate-meeting.js';
 import validateTreatment from '../support/validate-treatment.js';
@@ -195,6 +196,8 @@ router.post(
  * Ensures the prepublished behandeling that is signed is persisted in the store and attached to the document container
  */
 router.post('/signed-resources', async function (req, res, next) {
+  /** @type {Task | undefined} */
+  let signingTask;
   try {
     const { relationships } = parseBody(req.body);
     // @ts-ignore we could move to zod to get nice types here
@@ -205,6 +208,13 @@ router.post('/signed-resources', async function (req, res, next) {
       );
       const treatment = await Treatment.findUri(versionedTreatment.treatment);
       const meeting = await Meeting.findURI(treatment.meeting);
+      // Use a task but only for concurrency protection. Requests may timeout.
+      signingTask = await ensureTask(
+        meeting,
+        TASK_TYPE_SIGNING_VERSIONED_TREATMENT
+      );
+      signingTask = await signingTask.updateStatus(TASK_STATUS_RUNNING);
+
       const meetingErrors = validateMeeting(meeting);
       const treatmentErrors = await validateTreatment(treatment);
       const errors = [...meetingErrors, ...treatmentErrors];
@@ -223,6 +233,7 @@ router.post('/signed-resources', async function (req, res, next) {
           treatment.attachments
         );
         const signedResource = await SignedResource.findURI(signedResourceUri);
+        await signingTask.updateStatus(TASK_STATUS_SUCCESS);
         return res.send(signedResource.toMuResourceModel());
       }
     }
@@ -231,6 +242,7 @@ router.post('/signed-resources', async function (req, res, next) {
     const error = new Error(
       `An error occurred while signing the resource: ${err}`
     );
+    await signingTask?.updateStatus(TASK_STATUS_FAILURE, err.message);
     return next(error);
   }
 });

--- a/routes/signing.js
+++ b/routes/signing.js
@@ -1,10 +1,7 @@
-// @ts-strict-ignore
-
 import express from 'express';
 import Meeting from '../models/meeting.js';
 import Treatment from '../models/treatment.js';
-import SignedResource from '../models/signed-resource.js';
-import { ensureTask, returnEnsuredTaskId } from '../support/task-utils.js';
+import { returnEnsuredTaskId } from '../support/task-utils.js';
 import {
   TASK_STATUS_FAILURE,
   TASK_STATUS_RUNNING,
@@ -33,18 +30,6 @@ import {
   signVersionedExtract,
 } from '../support/extract-utils.js';
 import { fetchCurrentUser } from '../support/query-utils.js';
-import {
-  getCurrentVersion,
-  getLinkedDocuments,
-} from '../support/editor-document-utils.js';
-import {
-  ensureVersionedRegulatoryStatement,
-  signVersionedRegulatoryStatement,
-} from '../support/regulatory-statement-utils.js';
-import { getUri } from '../support/resource-utils.js';
-
-import { parseBody } from '../support/parse-body.js';
-import VersionedExtract from '../models/versioned-behandeling.js';
 /** @import Task from '../models/task' */
 
 const router = express.Router();
@@ -102,7 +87,7 @@ router.post(
         res,
         meeting,
         TASK_TYPE_SIGNING_DECISION_LIST,
-        userUri
+        userUri ?? undefined
       );
     } catch (err) {
       console.error('Error signing decision list', err);
@@ -124,6 +109,7 @@ router.post(
       );
       await signingTask.updateStatus(TASK_STATUS_SUCCESS);
     } catch (err) {
+      // @ts-ignore ignore unknown access
       signingTask.updateStatus(TASK_STATUS_FAILURE, err.message);
     }
   }
@@ -132,67 +118,11 @@ router.post(
 /**
  * Makes the current user sign the provided behandeling for the supplied document.
  * Ensures the prepublished behandeling that is signed is persisted in the store and attached to the document container
+ * The Task created has the signed resource uri connected to it, so that the status check can
+ * return the relevant data.
  */
 router.post(
-  '/signing/behandeling/sign/:zittingIdentifier/:behandelingUuid',
-  async function (req, res, next) {
-    try {
-      const [meeting, treatment] = await Promise.all([
-        Meeting.find(req.params.zittingIdentifier),
-        Treatment.find(req.params.behandelingUuid),
-      ]);
-      const meetingErrors = validateMeeting(meeting);
-      const treatmentErrors = await validateTreatment(treatment);
-      const errors = [...meetingErrors, ...treatmentErrors];
-      if (errors.length) {
-        return res.status(400).send({ errors }).end();
-      } else {
-        const extractUri = await ensureVersionedExtract(treatment, meeting);
-        await signVersionedExtract(
-          extractUri,
-          req.header('MU-SESSION-ID'),
-          'getekend',
-          treatment.attachments
-        );
-        const treatmentEditorDocumentUri = await getUri(
-          treatment.editorDocumentUuid
-        );
-        const linkedRegulatoryStatementContainers = await getLinkedDocuments(
-          treatmentEditorDocumentUri
-        );
-        const linkedRegulatoryStatementDocuments = await Promise.all(
-          linkedRegulatoryStatementContainers.map(async (containerURI) =>
-            getCurrentVersion(containerURI)
-          )
-        );
-        const versionedRegulatoryStatements = await Promise.all(
-          linkedRegulatoryStatementDocuments.map(async (doc) =>
-            ensureVersionedRegulatoryStatement(doc, extractUri)
-          )
-        );
-        await Promise.all(
-          versionedRegulatoryStatements.map(async (versionedStatementUri) =>
-            signVersionedRegulatoryStatement(
-              versionedStatementUri,
-              req.header('MU-SESSION-ID'),
-              'getekend'
-            )
-          )
-        );
-        return res.send({ success: true }).end();
-      }
-    } catch (err) {
-      console.error('Error signing behandeling', err);
-      const error = new Error(
-        `An error occurred while signing the behandeling ${req.params.behandelingUuid}: ${err}`
-      );
-      return next(error);
-    }
-  }
-);
-
-router.post(
-  '/signing/uittreksel/sign/:versionedTreatmentId',
+  '/signing/uittreksel/sign/:zittingIdentifier/:behandelingUuid',
   async function (req, res, next) {
     /** @type {Treatment | undefined} */
     let treatment;
@@ -201,18 +131,15 @@ router.post(
     /** @type {Task | undefined} */
     let signingTask;
     try {
-      if (req.params.versionedTreatmentId) {
-        const versionedTreatment = await VersionedExtract.find(
-          req.params.versionedTreatmentId
-        );
-        treatment = await Treatment.findUri(versionedTreatment.treatment);
-        meeting = await Meeting.findURI(treatment.meeting);
-        signingTask = await returnEnsuredTaskId(
-          res,
-          meeting,
-          TASK_TYPE_SIGNING_VERSIONED_TREATMENT
-        );
-      }
+      [meeting, treatment] = await Promise.all([
+        Meeting.find(req.params.zittingIdentifier),
+        Treatment.find(req.params.behandelingUuid),
+      ]);
+      signingTask = await returnEnsuredTaskId(
+        res,
+        meeting,
+        TASK_TYPE_SIGNING_VERSIONED_TREATMENT
+      );
     } catch (err) {
       console.error('Error while creating signed resource task', err);
       const error = new Error(
@@ -237,76 +164,26 @@ router.post(
             meeting
           );
 
-          await signVersionedExtract(
+          const signedResourceUri = await signVersionedExtract(
             versionedExtractUri,
             req.header('MU-SESSION-ID'),
             'getekend',
             treatment.attachments
           );
-          signingTask.updateStatus(TASK_STATUS_SUCCESS);
+          await signingTask.updateStatus(
+            TASK_STATUS_SUCCESS,
+            undefined,
+            signedResourceUri
+          );
         }
       }
     } catch (err) {
       console.error('Error while signing extract', err);
+      // @ts-ignore ignore unknown access
       await signingTask?.updateStatus(TASK_STATUS_FAILURE, err.message);
     }
   }
 );
-/**
- * Creates a signed resource for the provided resource (currently only a treatment is supported)
- * Ensures the prepublished behandeling that is signed is persisted in the store and attached to the document container
- */
-router.post('/signed-resources', async function (req, res, next) {
-  /** @type {Task | undefined} */
-  let signingTask;
-  try {
-    const { relationships } = parseBody(req.body);
-    // @ts-ignore we could move to zod to get nice types here
-    const versionedTreatmentUuid = relationships?.['versioned-behandeling']?.id;
-    if (versionedTreatmentUuid) {
-      const versionedTreatment = await VersionedExtract.find(
-        versionedTreatmentUuid
-      );
-      const treatment = await Treatment.findUri(versionedTreatment.treatment);
-      const meeting = await Meeting.findURI(treatment.meeting);
-      // Use a task but only for concurrency protection. Requests may timeout.
-      signingTask = await ensureTask(
-        meeting,
-        TASK_TYPE_SIGNING_VERSIONED_TREATMENT
-      );
-      signingTask = await signingTask.updateStatus(TASK_STATUS_RUNNING);
-
-      const meetingErrors = validateMeeting(meeting);
-      const treatmentErrors = await validateTreatment(treatment);
-      const errors = [...meetingErrors, ...treatmentErrors];
-      if (errors.length) {
-        return res.status(400).send({ errors }).end();
-      } else {
-        const versionedExtractUri = await ensureVersionedExtract(
-          treatment,
-          meeting
-        );
-
-        const signedResourceUri = await signVersionedExtract(
-          versionedExtractUri,
-          req.header('MU-SESSION-ID'),
-          'getekend',
-          treatment.attachments
-        );
-        const signedResource = await SignedResource.findURI(signedResourceUri);
-        await signingTask.updateStatus(TASK_STATUS_SUCCESS);
-        return res.send(signedResource.toMuResourceModel());
-      }
-    }
-  } catch (err) {
-    console.error('Error while creating signed resource', err);
-    const error = new Error(
-      `An error occurred while signing the resource: ${err}`
-    );
-    await signingTask?.updateStatus(TASK_STATUS_FAILURE, err.message);
-    return next(error);
-  }
-});
 
 /**
  * Makes the current user sign the notulen for the supplied document.
@@ -327,10 +204,11 @@ router.post(
         res,
         meeting,
         TASK_TYPE_SIGNING_MEETING_NOTES,
-        userUri
+        userUri ?? undefined
       );
     } catch (err) {
       console.error('Error attempting to create signing task', err);
+      // @ts-ignore ignore unknown access
       await signingTask?.updateStatus(TASK_STATUS_FAILURE, err.message);
       const error = new Error(
         `An error occurred while signing the meeting notes ${req.params.zittingIdentifier}: ${err}`
@@ -350,7 +228,7 @@ router.post(
       for (const treatment of treatments) {
         const treatmentErrors = await validateTreatment(treatment);
         errors = [...errors, ...treatmentErrors];
-        attachments.push(...treatment.attachments);
+        attachments.push(...(treatment.attachments ?? []));
       }
       if (errors.length) {
         throw new Error(errors.join(', '));
@@ -370,6 +248,7 @@ router.post(
       await signingTask.updateStatus(TASK_STATUS_SUCCESS);
     } catch (err) {
       console.error('Error signing notulen', err);
+      // @ts-ignore ignore unknown access
       await signingTask.updateStatus(TASK_STATUS_FAILURE, err.message);
     }
   }

--- a/routes/task.js
+++ b/routes/task.js
@@ -1,5 +1,6 @@
 import express from 'express';
-import Task from '../models/task.js';
+import Task, { TASK_TYPE_SIGNING_VERSIONED_TREATMENT } from '../models/task.js';
+import SignedResource from '../models/signed-resource.js';
 
 const router = express.Router();
 
@@ -7,6 +8,16 @@ router.get('/publication-tasks/:id', async function (req, res, next) {
   const taskUuid = req.params.id;
   try {
     const task = await Task.find(taskUuid);
+    let payload;
+    if (
+      task.type === TASK_TYPE_SIGNING_VERSIONED_TREATMENT &&
+      task.createdResource
+    ) {
+      // TODO we could probably do more sanity checking here as if the signed resource does not
+      // exist this will fail
+      const signedResource = await SignedResource.findURI(task.createdResource);
+      payload = signedResource.toMuResourceModel();
+    }
     res.status(200).send({
       data: {
         id: task.id,
@@ -17,6 +28,7 @@ router.get('/publication-tasks/:id', async function (req, res, next) {
         modified: task.modified,
         involves: task.involves,
         taskType: task.type,
+        payload,
         error: task.error
           ? {
               id: task.error.id,

--- a/support/task-utils.js
+++ b/support/task-utils.js
@@ -1,23 +1,15 @@
 /** @import { Response } from 'express' */
 import Task from '../models/task.js';
-import AppError from './error-utils.js';
 /** @import Meeting from '../models/meeting' */
 
 /**
+ * @deprecated This function is now just a wrapper around `Task.create()`
  * @param {Meeting} meeting
  * @param {string} taskType
  * @param {string} [userUri]
  * */
 export async function ensureTask(meeting, taskType, userUri) {
-  /** @type {Task | null} */
-  let task = null;
-  if (!task) {
-    task = await Task.create(meeting, taskType, userUri);
-  }
-  if (!task) {
-    throw new AppError(500, 'Unable to create task');
-  }
-  return task;
+  return Task.create(meeting, taskType, userUri);
 }
 
 /**
@@ -27,7 +19,7 @@ export async function ensureTask(meeting, taskType, userUri) {
  * @param {string} [userUri]
  * */
 export async function returnEnsuredTaskId(res, meeting, taskType, userUri) {
-  const task = await ensureTask(meeting, taskType, userUri);
+  const task = await Task.create(meeting, taskType, userUri);
 
   res.status(202).json({
     data: {


### PR DESCRIPTION
Based on https://github.com/lblod/notulen-prepublish-service/pull/131

Wraps the signing process in a task to prevent concurrency~~, but keep the 'sync' endpoint, so if the task takes too long it times out. This causes a weird frontend state, but is likely preferable to broken signing.~~

~~There is a remaining issue around creation of versioned behandelingen, as opening the extract signing page with 2 different users in quick succession leads to each having a different one. This then causes signing to fail. This PR is a draft until that is fixed.~~

This adds a feature to Tasks that allows for returning data and uses it for signed resources. This allows caching issues to be worked around.