### PR TITLE
Generate linked decision warnings

### DIFF
--- a/models/decision.js
+++ b/models/decision.js
@@ -40,6 +40,10 @@ export default class Decision {
       (t) => t.predicate === 'http://data.europa.eu/eli/ontology#description'
     );
     const description = descriptionTriple?.object;
+    const linkedDecisionTriple = triples.find(
+      (t) => t.predicate === 'http://data.europa.eu/eli/ontology#consolidates'
+    );
+    const linkedDecision = linkedDecisionTriple?.object;
     const types = triples
       .filter(
         (t) =>
@@ -48,14 +52,15 @@ export default class Decision {
       )
       .map((type) => type.object);
     const uri = triples[0].subject;
-    return new Decision({ title, description, types, uri });
+    return new Decision({ title, description, types, uri, linkedDecision });
   }
 
-  constructor({ uri, title, description, types }) {
+  constructor({ uri, title, description, types, linkedDecision }) {
     this.uri = uri;
     this.title = title;
     this.description = description;
     this.types = types;
     this.typesAsText = types.join(' ');
+    this.linkedDecision = linkedDecision;
   }
 }

--- a/routes/preview.js
+++ b/routes/preview.js
@@ -192,13 +192,13 @@ router.get(
   '/prepublish/notulen/:zittingIdentifier',
   handleWithJob(
     async (req) => {
-      const { html, errors } = await constructHtmlForMeetingNotes(
+      const { html, errors, warnings } = await constructHtmlForMeetingNotes(
         req.params.zittingIdentifier,
         true
       );
       return {
         data: {
-          attributes: { content: html, errors },
+          attributes: { content: html, errors, warnings },
           type: 'imported-notulen-contents',
         },
       };
@@ -219,7 +219,9 @@ router.post('/extract-previews', async function (req, res, next) {
     const html = constructHtmlForExtract(extractData);
 
     let errors = validateMeeting(extractData.meeting);
-    errors = errors.concat(await validateTreatment(extractData.treatment));
+    const { errors: treatmentErrors, warnings: treatmentWarnings } =
+      await validateTreatment(extractData.treatment);
+    errors = errors.concat(treatmentErrors);
     return res
       .status(201)
       .send({
@@ -229,6 +231,7 @@ router.post('/extract-previews', async function (req, res, next) {
           attributes: {
             html: html,
             'validation-errors': errors,
+            'validation-warnings': treatmentWarnings,
           },
           relationships: {
             treatment: {

--- a/routes/publication.js
+++ b/routes/publication.js
@@ -134,7 +134,7 @@ router.post(
         Treatment.find(req.params.behandelingUuid),
       ]);
       const meetingErrors = validateMeeting(meeting);
-      const treatmentErrors = await validateTreatment(treatment);
+      const { errors: treatmentErrors } = await validateTreatment(treatment);
       const errors = [...meetingErrors, ...treatmentErrors];
       if (errors.length) {
         return res.status(400).send({ errors }).end();
@@ -215,7 +215,7 @@ router.post(
       let errors = validateMeeting(meeting);
       const attachments = [];
       for (const treatment of treatments) {
-        const treatmentErrors = await validateTreatment(treatment);
+        const { errors: treatmentErrors } = await validateTreatment(treatment);
         errors = [...errors, ...treatmentErrors];
         if (treatment.attachments) {
           attachments.push(...treatment.attachments);

--- a/routes/signing.js
+++ b/routes/signing.js
@@ -151,7 +151,7 @@ router.post(
       if (treatment && meeting && signingTask) {
         signingTask = await signingTask.updateStatus(TASK_STATUS_RUNNING);
         const meetingErrors = validateMeeting(meeting);
-        const treatmentErrors = await validateTreatment(treatment);
+        const { errors: treatmentErrors } = await validateTreatment(treatment);
         const errors = [...meetingErrors, ...treatmentErrors];
         if (errors.length) {
           await signingTask.updateStatus(
@@ -226,7 +226,7 @@ router.post(
       let errors = validateMeeting(meeting);
       const attachments = [];
       for (const treatment of treatments) {
-        const treatmentErrors = await validateTreatment(treatment);
+        const { errors: treatmentErrors } = await validateTreatment(treatment);
         errors = [...errors, ...treatmentErrors];
         attachments.push(...(treatment.attachments ?? []));
       }

--- a/support/besluit-types.js
+++ b/support/besluit-types.js
@@ -1,0 +1,96 @@
+const BESLUIT_TYPES = {
+  'Reglementen en verordeningen':
+    'https://data.vlaanderen.be/id/concept/BesluitType/67378dd0-5413-474b-8996-d992ef81637a',
+  'Rechtspositieregeling (RPR)':
+    'https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8',
+  'Meerjarenplan(aanpassing)':
+    'https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f',
+  'Jaarrekening PEVA':
+    'https://data.vlaanderen.be/id/concept/BesluitType/0a8141bc-cf35-43dd-855d-365fa32ad89b',
+  'Oprichting autonoom bedrijf':
+    'https://data.vlaanderen.be/id/concept/BesluitType/bd0b0c42-ba5e-4acc-b644-95f6aad904c7',
+  'Oprichting of deelname EVA':
+    'https://data.vlaanderen.be/id/concept/BesluitType/f8c070bd-96e4-43a1-8c6e-532bcd771251',
+  'Oprichting IGS':
+    'https://data.vlaanderen.be/id/concept/BesluitType/1105564e-30c7-4371-a864-6b7329cdae6f',
+  'Oprichting districtsbestuur':
+    'https://data.vlaanderen.be/id/concept/BesluitType/380674ee-0894-4c41-bcc1-9deaeb9d464c',
+  Retributiereglement:
+    'https://data.vlaanderen.be/id/concept/BesluitType/ba5922c9-cfad-4b2e-b203-36479219ba56',
+  Personeelsreglement:
+    'https://data.vlaanderen.be/id/concept/BesluitType/4673d472-8dbc-4cea-b3ab-f92df3807eb3',
+  'Aanvullend reglement op het wegverkeer m.b.t. gemeentewegen in speciale beschermingszones':
+    'https://data.vlaanderen.be/id/concept/BesluitType/4673d472-8dbc-4cea-b3ab-f92df3807eb3',
+  Gebruikersreglement:
+    'https://data.vlaanderen.be/id/concept/BesluitType/fb92601a-d189-4482-9922-ab0efc6bc935',
+  Belastingreglement:
+    'https://data.vlaanderen.be/id/concept/BesluitType/efa4ec5a-b006-453f-985f-f986ebae11bc',
+  Contantbelasting:
+    'https://data.vlaanderen.be/id/concept/BesluitType/4c22ef0a-f808-41dd-9c9f-2aff17fd851f',
+  'Aanvullende belasting of opcentiem':
+    'https://data.vlaanderen.be/id/concept/BesluitType/b2d0734d-13d0-44b4-9af8-1722933c5288',
+  Kohierbelasting:
+    'https://data.vlaanderen.be/id/concept/BesluitType/8597e056-b96d-4213-ad4c-37338f2aaf35',
+  'Huishoudelijk reglement':
+    'https://data.vlaanderen.be/id/concept/BesluitType/a8486fa3-6375-494d-aa48-e34289b87d5b',
+  'Deontologische Code':
+    'https://data.vlaanderen.be/id/concept/BesluitType/25deb453-ae3e-4d40-8027-36cdb48ab738',
+  'Reglement Onderwijs':
+    'https://data.vlaanderen.be/id/concept/BesluitType/e8aee49e-8762-4db2-acfe-2d5dd3c37619',
+  'Subsidie, premie, erkenning':
+    'https://data.vlaanderen.be/id/concept/BesluitType/d7060f97-c417-474c-abc6-ef006cb61f41',
+  'Tijdelijke politieverordening (op het wegverkeer)':
+    'https://data.vlaanderen.be/id/concept/BesluitType/256bd04a-b74b-4f2a-8f5d-14dda4765af9',
+  'Aanvullend reglement op het wegverkeer m.b.t. gemeentewegen in havengebied':
+    'https://data.vlaanderen.be/id/concept/BesluitType/3bba9f10-faff-49a6-acaa-85af7f2199a3',
+  Politiereglement:
+    'https://data.vlaanderen.be/id/concept/BesluitType/e8afe7c5-9640-4db8-8f74-3f023bec3241',
+  'Aanvullend reglement op het wegverkeer enkel m.b.t. gemeentewegen (niet in havengebied of speciale beschermingszones)':
+    'https://data.vlaanderen.be/id/concept/BesluitType/4d8f678a-6fa4-4d5f-a2a1-80974e43bf34',
+  Delegatiereglement:
+    'https://data.vlaanderen.be/id/concept/BesluitType/5ee63f84-2fa0-4758-8820-99dca2bdce7c',
+  Andere:
+    'https://data.vlaanderen.be/id/concept/BesluitType/84121221-4217-40e3-ada2-cd1379b168e1',
+  'Aanvullend reglement op het wegverkeer m.b.t. één of meerdere gewestwegen':
+    'https://data.vlaanderen.be/id/concept/BesluitType/7d95fd2e-3cc9-4a4c-a58e-0fbc408c2f9b',
+};
+
+export const DECISION_TYPES_TO_LINK = [
+  BESLUIT_TYPES['Reglementen en verordeningen'],
+  BESLUIT_TYPES['Rechtspositieregeling (RPR)'],
+  BESLUIT_TYPES['Meerjarenplan(aanpassing)'],
+  BESLUIT_TYPES['Jaarrekening PEVA'],
+  BESLUIT_TYPES['Oprichting autonoom bedrijf'],
+  BESLUIT_TYPES['Oprichting of deelname EVA'],
+  BESLUIT_TYPES['Oprichting IGS'],
+  BESLUIT_TYPES['Oprichting districtsbestuur'],
+  BESLUIT_TYPES['Retributiereglement'],
+  BESLUIT_TYPES['Personeelsreglement'],
+  BESLUIT_TYPES[
+    'Aanvullend reglement op het wegverkeer m.b.t. gemeentewegen in speciale beschermingszones'
+  ],
+  BESLUIT_TYPES['Gebruikersreglement'],
+  BESLUIT_TYPES['Belastingreglement'],
+  BESLUIT_TYPES['Contantbelasting'],
+  BESLUIT_TYPES['Aanvullende belasting of opcentiem'],
+  BESLUIT_TYPES['Kohierbelasting'],
+  BESLUIT_TYPES['Huishoudelijk reglement'],
+  BESLUIT_TYPES['Deontologische Code'],
+  BESLUIT_TYPES['Reglement Onderwijs'],
+  BESLUIT_TYPES['Subsidie, premie, erkenning'],
+  BESLUIT_TYPES['Tijdelijke politieverordening (op het wegverkeer)'],
+  BESLUIT_TYPES[
+    'Aanvullend reglement op het wegverkeer m.b.t. gemeentewegen in havengebied'
+  ],
+  BESLUIT_TYPES['Politiereglement'],
+  BESLUIT_TYPES[
+    'Aanvullend reglement op het wegverkeer enkel m.b.t. gemeentewegen (niet in havengebied of speciale beschermingszones)'
+  ],
+  BESLUIT_TYPES['Delegatiereglement'],
+  BESLUIT_TYPES['Andere'],
+  BESLUIT_TYPES[
+    'Aanvullend reglement op het wegverkeer m.b.t. één of meerdere gewestwegen'
+  ],
+];
+
+export default BESLUIT_TYPES;

--- a/support/extract-utils.js
+++ b/support/extract-utils.js
@@ -50,12 +50,14 @@ async function buildExtractForTreatment(
     participantCache
   );
   const html = constructHtmlForExtract(data);
-  const treatmentErrors = await validateTreatment(treatment);
+  const { errors: treatmentErrors, warnings: treatmentWarnings } =
+    await validateTreatment(treatment);
   return {
     data: {
       attributes: {
         content: html,
         errors: [...meetingErrors, ...treatmentErrors],
+        warnings: treatmentWarnings,
         behandeling: treatment.uri,
         uuid: treatment.uuid,
       },
@@ -74,6 +76,7 @@ export async function buildAllExtractsForMeeting(meetingUuid) {
   if (participationList) {
     participantCache = buildParticipantCache(participationList);
   }
+  
   const meetingErrors = validateMeeting(meeting);
   const extractBuilders = treatments.map((treatment) =>
     buildExtractForTreatment(

--- a/support/extract-utils.js
+++ b/support/extract-utils.js
@@ -76,7 +76,7 @@ export async function buildAllExtractsForMeeting(meetingUuid) {
   if (participationList) {
     participantCache = buildParticipantCache(participationList);
   }
-  
+
   const meetingErrors = validateMeeting(meeting);
   const extractBuilders = treatments.map((treatment) =>
     buildExtractForTreatment(

--- a/support/notulen-utils.js
+++ b/support/notulen-utils.js
@@ -33,9 +33,12 @@ export async function constructHtmlForMeetingNotes(meetingUuid, previewType) {
   const meeting = await Meeting.find(meetingUuid);
   const treatments = await Treatment.findAll({ meetingUuid });
   let errors = validateMeeting(meeting);
+  let warnings = [];
   for (const treatment of treatments) {
-    const treatmentErrors = await validateTreatment(treatment);
+    const { errors: treatmentErrors, warnings: treatmentWarnings } =
+      await validateTreatment(treatment);
     errors = [...errors, ...treatmentErrors];
+    warnings = [...warnings, ...treatmentWarnings];
   }
   const meetingNotesData = await buildDataForMeetingNotes({
     meeting,
@@ -44,7 +47,7 @@ export async function constructHtmlForMeetingNotes(meetingUuid, previewType) {
     allPublic: true,
   });
   const html = constructHtmlForMeetingNotesFromData(meetingNotesData);
-  return { errors, html };
+  return { errors, warnings, html };
 }
 
 export async function buildDataForMeetingNotes({

--- a/support/validate-treatment.js
+++ b/support/validate-treatment.js
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import Decision from '../models/decision.js';
 import { DECISION_TYPES_TO_LINK } from './besluit-types.js';
 /**

--- a/support/validate-treatment.js
+++ b/support/validate-treatment.js
@@ -1,4 +1,5 @@
 import Decision from '../models/decision.js';
+import { DECISION_TYPES_TO_LINK } from './besluit-types.js';
 /**
  * @import Treatment from '../models/treatment'
  */
@@ -19,10 +20,12 @@ const errorMessages = {
  */
 export default async function validateTreatment(treatment) {
   const errors = [];
+  const warnings = [];
   const documentId = treatment.editorDocumentUuid;
   if (documentId) {
     const decisions = await Decision.extractDecisionsFromDocument(documentId);
     for (let decision of decisions) {
+      console.log(JSON.stringify(decision));
       if (
         !decision.typesAsText.includes(
           'https://data.vlaanderen.be/id/concept/BesluitType/'
@@ -30,7 +33,22 @@ export default async function validateTreatment(treatment) {
       ) {
         errors.push(errorMessages.nl.besluitTypeRequired(decision.title));
       }
+      if (
+        !decision.linkedDecision &&
+        decision.types.filter((value) => DECISION_TYPES_TO_LINK.includes(value))
+          .length
+      ) {
+        warnings.push({
+          treatmentUri: treatment.uri,
+          documentContainerUri: treatment.documentContainerUri,
+          decisionTitle: decision.title,
+          type: 'linkedDecision',
+          decisionType: decision.types.filter((value) =>
+            DECISION_TYPES_TO_LINK.includes(value)
+          )[0],
+        });
+      }
     }
   }
-  return errors;
+  return { errors, warnings };
 }


### PR DESCRIPTION
When you preview a extract we now generate warnings if that extract is of a type that accepts linked decisions and one is not set.
To be tested together with the frontend PR https://github.com/lblod/frontend-gelinkt-notuleren/pull/936